### PR TITLE
add models for attaching notes to servers and applications

### DIFF
--- a/plexus/main/migrations/0002_auto_20141219_1407.py
+++ b/plexus/main/migrations/0002_auto_20141219_1407.py
@@ -1,0 +1,56 @@
+# flake8: noqa
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('main', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ApplicationNote',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('application', models.ForeignKey(to='main.Application')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='Note',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('body', models.TextField(default='', blank=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='ServerNote',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('note', models.ForeignKey(to='main.Note')),
+                ('server', models.ForeignKey(to='main.Server')),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+        migrations.AddField(
+            model_name='applicationnote',
+            name='note',
+            field=models.ForeignKey(to='main.Note'),
+            preserve_default=True,
+        ),
+    ]

--- a/plexus/main/models.py
+++ b/plexus/main/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.contrib.auth.models import User
 
 
 class Location(models.Model):
@@ -273,3 +274,19 @@ class ServerContact(models.Model):
 
     def __unicode__(self):
         return unicode(self.server) + ": " + unicode(self.contact)
+
+
+class Note(models.Model):
+    user = models.ForeignKey(User)
+    created = models.DateTimeField(auto_now_add=True)
+    body = models.TextField(blank=True, default=u"")
+
+
+class ServerNote(models.Model):
+    server = models.ForeignKey(Server)
+    note = models.ForeignKey(Note)
+
+
+class ApplicationNote(models.Model):
+    application = models.ForeignKey(Application)
+    note = models.ForeignKey(Note)


### PR DESCRIPTION
Figured it would be nice to be able to write short notes on servers and applications. So a very simple model with user/timestamp/text. A logged in user will be able to just quickly add a note and the server/application page will then show all the notes. I'm inclined towards this timestamped note approach instead of a single wiki-ish field on each model because I think it's handy to have the history with dates and user attribution right there next to every note. This will also give us a way to log simple events like "LITO moved this server to a different blade". Manually for now and maybe eventually via automated scripts (automatically log reboots, etc).

This commit is just the model additions and a migration to get them deployed to production before any actual feature development happens.
