### PR TITLE
coverage reporting fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ jenkins: ./ve/bin/python validate test flake8
 	./bootstrap.py
 
 test: ./ve/bin/python
-	$(MANAGE) jenkins
+	$(MANAGE) jenkins --pep8-exclude=migrations --enable-coverage --coverage-rcfile=.coveragerc
 
 flake8: ./ve/bin/python
 	$(FLAKE8) $(APP) --max-complexity=8

--- a/plexus/settings_shared.py
+++ b/plexus/settings_shared.py
@@ -40,8 +40,6 @@ NOSE_ARGS = [
 ]
 
 JENKINS_TASKS = (
-    'django_jenkins.tasks.run_pylint',
-    'django_jenkins.tasks.with_coverage',
     'django_jenkins.tasks.run_pep8',
     'django_jenkins.tasks.run_pyflakes',
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ python-subunit==0.0.18
 lettuce==0.2.19ccnmtl
 rdflib==3.1.0
 selenium==2.20.0
-coverage==3.5.3
+coverage==3.7.1
 pep8==1.4
 pyflakes==0.5.0
 flake8==1.7.0


### PR DESCRIPTION
newer versions of django-jenkins do the weird thing where they don't
properly report code coverage on the code that's executed at import
(something to do with how django changed the application importing
mechanism).

This is a bit odd, but seems to be what is needed to get it
to produce full coverage reports
