### PR TITLE
Add python-dateutil for UTC S3 fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ sqlparse==0.1.13
 gunicorn==19.1.1
 boto==2.34.0
 six==1.8.0
+python-dateutil==2.4.0
 
 djangowind==0.13.2
 django-indexer==0.3.0


### PR DESCRIPTION
I didn't run the tests locally, but I'm glad jenkins caught this: http://jenkins.ccnmtl.columbia.edu/job/plexus-staging/85/console