### PR TITLE
use Cloudfront for serving static files

### DIFF
--- a/plexus/settings_production.py
+++ b/plexus/settings_production.py
@@ -31,12 +31,13 @@ DATABASES = {
         }
 }
 
+AWS_S3_CUSTOM_DOMAIN = "d35pxobnzf6ttf.cloudfront.net"
 AWS_STORAGE_BUCKET_NAME = "ccnmtl-plexus-static-prod"
 AWS_PRELOAD_METADATA = True
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 STATICFILES_STORAGE = 'plexus.s3utils.MediaRootS3BotoStorage'
-S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
-STATIC_URL = 'https://%s.s3.amazonaws.com/media/' % AWS_STORAGE_BUCKET_NAME
+S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
+STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 COMPRESS_ROOT = STATIC_ROOT

--- a/plexus/settings_staging.py
+++ b/plexus/settings_staging.py
@@ -33,12 +33,13 @@ DATABASES = {
         }
 }
 
+AWS_S3_CUSTOM_DOMAIN = "d1vy4q2u1y7bpg.cloudfront.net"
 AWS_STORAGE_BUCKET_NAME = "ccnmtl-plexus-static-stage"
 AWS_PRELOAD_METADATA = True
 DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 STATICFILES_STORAGE = 'plexus.s3utils.MediaRootS3BotoStorage'
-S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
-STATIC_URL = 'https://%s.s3.amazonaws.com/media/' % AWS_STORAGE_BUCKET_NAME
+S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
+STATIC_URL =  'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
 COMPRESS_ENABLED = True
 COMPRESS_OFFLINE = True
 COMPRESS_ROOT = STATIC_ROOT


### PR DESCRIPTION
Played around with Cloudfront this weekend and realized that it's fairly trivial to convert our stuff over to use cloudfront instead of serving direct from S3. Latency is definitely lower (especially from Europe), and it's actually a bit cheaper.

In the AWS console, you just go into Cloudfront and create a new distribution, using one of our S3 static buckets as the origin. Everything else can be left as default. It takes 15-20 minutes for it to be fully setup (DNS propagation). Then, just take note of the random domain it generated, and put it into the `AWS_S3_CUSTOM_DOMAIN` settings and tweak the URLs.