### PR TITLE
convert server graphs from cubism.js to plain graphite image graphs

### DIFF
--- a/plexus/templates/main/application_detail.html
+++ b/plexus/templates/main/application_detail.html
@@ -102,6 +102,9 @@
 
 
 <h2>Graphs</h2>
+{% with graphite_base="https://nanny-render.cul.columbia.edu/render/" %}
+{% with graphite_name=object.graphite_name %}
+{% with width=900 height=200 %}
 <ul class="nav nav-tabs">
   <li><a href="#daily" data-toggle="tab">Daily</a></li>
   <li><a href="#weekly" data-toggle="tab">Weekly</a></li>
@@ -111,20 +114,29 @@
 
 <div class="tab-content">
   <div class="tab-pane active" id="daily">
-    <div id="graphs-daily"></div>
+{% with from="-24hours" %}
+    {% include "main/application_graphs.html" %}
+{% endwith %}
   </div>
-
   <div class="tab-pane" id="weekly">
-    <div id="graphs-weekly"></div>
+{% with from="-7days" %}
+    {% include "main/application_graphs.html" %}
+{% endwith %}
   </div>
-
   <div class="tab-pane" id="monthly">
-    <div id="graphs-monthly"></div>
+{% with from="-4weeks" %}
+    {% include "main/application_graphs.html" %}
+{% endwith %}
   </div>
   <div class="tab-pane" id="yearly">
-    <div id="graphs-yearly"></div>
+{% with from="-1years" %}
+    {% include "main/application_graphs.html" %}
+{% endwith %}
   </div>
 </div>
+{% endwith %}
+{% endwith %}
+{% endwith %}
 {% endif %}
 
 {% if object.pmt_id %}
@@ -142,20 +154,12 @@
 {% endblock %}
 
 {% block js %}
-{% if object.graphite_name %}
 <script src="{{STATIC_URL}}js/d3.v2.min.js"></script>
-<script src="{{STATIC_URL}}js/cubism.v1.min.js"></script>
 <script src="{{STATIC_URL}}js/smoketests.js"></script>
-<script src="{{STATIC_URL}}js/makegraphs.js"></script>
 <script>
 (function () {
-  var width = $("#graphs-daily").width();
-  window.makegraphs("#graphs-daily", "{{object.graphite_name}}", width, 1e5);
-  window.makegraphs("#graphs-weekly", "{{object.graphite_name}}", width, 7e5);
-  window.makegraphs("#graphs-monthly", "{{object.graphite_name}}", width, 30e5);
-  window.makegraphs("#graphs-yearly", "{{object.graphite_name}}", width, 365e5);
   window.makesmoketests("#smoketests", "{{object.graphite_name}}");
 }());
 </script>
-{% endif %}
+
 {% endblock %}

--- a/plexus/templates/main/application_graphs.html
+++ b/plexus/templates/main/application_graphs.html
@@ -1,0 +1,32 @@
+{% with metric_base="ccnmtl.app.counters.nginx."|add:graphite_name %}
+<h3>Smoketests Failed</h3>
+{% with metric="keepLastValue(ccnmtl.app.smoketest."|add:graphite_name|add:".failed)" %}
+{% include "main/graphite_graph.html" %}
+{% endwith %}
+
+<h3>Requests Per Minute</h3>
+{% with metric="sumSeries("|add:metric_base|add:".status.*.count)" %}
+{% include "main/graphite_graph.html" %}
+{% endwith %}
+
+<h3>Request Time</h3>
+{% with metric="ccnmtl.app.timers.nginx."|add:graphite_name|add:".request_time.mean&target=ccnmtl.app.timers.nginx."|add:graphite_name|add:".request_time.upper_90" %}
+{% include "main/graphite_graph.html" %}
+{% endwith %}
+
+<h3>% 5xxs</h3>
+{% with metric="divideSeries(sumSeries("|add:metric_base|add:".status.5*.count),sumSeries("|add:metric_base|add:".status.*.count))" %}
+{% include "main/graphite_graph.html" %}
+{% endwith %}
+
+<h3>500s per minute</h3>
+{% with metric=metric_base|add:".status.5*.count" %}
+{% include "main/graphite_graph.html" %}
+{% endwith %}
+
+<h3>404s</h3>
+{% with metric=metric_base|add:".status.404.count" %}
+{% include "main/graphite_graph.html" %}
+{% endwith %}
+
+{% endwith %}

--- a/plexus/templates/main/graphite_graph.html
+++ b/plexus/templates/main/graphite_graph.html
@@ -1,0 +1,1 @@
+<img src="{{graphite_base}}?target={{metric}}{{ymin}}{{ymax}}&width={{width}}&height={{height}}&bgcolor=FFFFFF&fgcolor=000000&colorList=%23999999,%23006699&from={{from}}" width="{{width}}" height="{{height}}" />

--- a/plexus/templates/main/server_detail.html
+++ b/plexus/templates/main/server_detail.html
@@ -260,7 +260,9 @@
 
 {% if object.graphite_name %}
 <h2>Graphs</h2>
-
+{% with graphite_base="https://nanny-render.cul.columbia.edu/render/" %}
+{% with graphite_name=object.graphite_name %}
+{% with width=900 height=200 %}
 <ul class="nav nav-tabs">
   <li><a href="#daily" data-toggle="tab">Daily</a></li>
   <li><a href="#weekly" data-toggle="tab">Weekly</a></li>
@@ -270,106 +272,31 @@
 
 <div class="tab-content">
   <div class="tab-pane active" id="daily">
-    <div id="graphs-daily"></div>
+{% with from="-24hours" %}
+    {% include "main/server_graphs.html" %}
+{% endwith %}
   </div>
   <div class="tab-pane" id="weekly">
-    <div id="graphs-weekly"></div>
+{% with from="-7days" %}
+    {% include "main/server_graphs.html" %}
+{% endwith %}
   </div>
   <div class="tab-pane" id="monthly">
-    <div id="graphs-monthly"></div>
+{% with from="-4weeks" %}
+    {% include "main/server_graphs.html" %}
+{% endwith %}
   </div>
   <div class="tab-pane" id="yearly">
-   <div id="graphs-yearly"></div>
+{% with from="-1years" %}
+    {% include "main/server_graphs.html" %}
+{% endwith %}
   </div>
 </div>
+{% endwith %}
+{% endwith %}
+{% endwith %}
 {% endif %}
 
 
-{% endblock %}
-
-{% block js %}
-{% if object.graphite_name %}
-<script src="{{STATIC_URL}}js/d3.v2.min.js"></script>
-<script src="{{STATIC_URL}}js/cubism.v1.min.js"></script>
-<script>
-
-var makegraphs = function (el, size, step) {
-var context = cubism.context(), // a default context
-      graphite = context.graphite("");
-  
-  context.size(size).step(step);
-  
-  var metric_base = "ccnmtl.server.{{object.graphite_name}}";
-  
-  var metric_defs = [
-    {
-      metric: metric_base + ".cpu.load_average.1_minute",
-      alias: "Load Avg"
-    },
-    {
-      metric: metric_base + ".memory.MemFree.percent",
-      alias: "Free Mem"
-    },
-    {
-      metric: "nonNegativeDerivative(" + metric_base + ".network.eth0.receive.byte_count)",
-      alias: "Eth0 in"
-    },
-    {
-      metric: "nonNegativeDerivative(" + metric_base + ".network.eth0.transmit.byte_count)",
-      alias: "Eth0 out"
-    },
-    {
-      metric: "nonNegativeDerivative(" + metric_base + ".vmstat.swap.in)",
-      alias: "Swap in"
-    },
-    {
-      metric: "nonNegativeDerivative(" + metric_base + ".vmstat.swap.out)",
-      alias: "Swap out"
-    },
-    {
-      metric: "asPercent(" + metric_base + ".disk.usage.available," + metric_base + ".disk.usage.total)",
-      alias: "Disk Available (%)"
-    },
-    {
-      metric: "asPercent(" + metric_base + ".disk.inode.used," + metric_base + ".disk.inode.total)",
-      alias: "Inodes Used (%)"
-    }
-
-  ];
-  
-  var gmetric = function(metric_def) {
-     return graphite.metric(metric_def.metric).alias(metric_def.alias);
-  };
-  
-  var metrics = metric_defs.map(gmetric);
-  
-  d3.select(el).call(function(div) {
-    div.append("div")
-        .attr("class", "axis")
-        .call(context.axis().orient("top"));
-  
-    div.selectAll(".horizon")
-      .data([metrics[0], metrics[1],
-             metrics[2].add(metrics[3]),
-             metrics[4].add(metrics[5]),
-             metrics[6], metrics[7]])
-      .enter().append("div")
-        .attr("class", "horizon")
-        
-        .call(context.horizon()
-          .colors(["#08519c", "#*82bd", "#6baed6", "#fee6ce", "#fdae6b", "#e6550d" ])
-          .height(120));
-  });
-};
-
-(function () {
-  var width = $("#graphs-daily").width();
-  window.makegraphs("#graphs-daily", width, 1e5);
-  window.makegraphs("#graphs-weekly", width, 7e5);
-  window.makegraphs("#graphs-monthly", width, 30e5);
-  window.makegraphs("#graphs-yearly", width, 365e5);
-}());
-</script>
-{% endif %}
 {% endblock %}
 

--- a/plexus/templates/main/server_graphs.html
+++ b/plexus/templates/main/server_graphs.html
@@ -10,12 +10,12 @@
 {% endwith %}
 
 <h3>Eth0 in + Eth0 out</h3>
-{% with metric="nonNegativeDerivative("|add:metric_base|add:".network.eth0.receive.byte_count)&target=nonNegativeDerivative("|add:metric_base|add:".network.eth0.transmit.byte_count)" %}
+{% with metric="scale(nonNegativeDerivative("|add:metric_base|add:".network.eth0.receive.byte_count),-1)&target=nonNegativeDerivative("|add:metric_base|add:".network.eth0.transmit.byte_count)" %}
 {% include "main/graphite_graph.html" %}
 {% endwith %}
 
 <h3>Swap in + out</h3>
-{% with metric="nonNegativeDerivative("|add:metric_base|add:".vmstat.swap.in)&target=nonNegativeDerivative("|add:metric_base|add:".vmstat.swap.out)" %}
+{% with metric="scale(nonNegativeDerivative("|add:metric_base|add:".vmstat.swap.in),-1)&target=nonNegativeDerivative("|add:metric_base|add:".vmstat.swap.out)" %}
 {% include "main/graphite_graph.html" %}
 {% endwith %}
 

--- a/plexus/templates/main/server_graphs.html
+++ b/plexus/templates/main/server_graphs.html
@@ -4,13 +4,14 @@
 {% with metric=metric_base|add:".cpu.load_average.1_minute" %}
 {% include "main/graphite_graph.html" %}
 {% endwith %}
-<h3>Free Mem</h3>
-{% with metric=metric_base|add:".memory.MemFree.percent" %}
-{% include "main/graphite_graph.html" %}
-{% endwith %}
 
 <h3>Eth0 in + Eth0 out</h3>
 {% with metric="scale(nonNegativeDerivative("|add:metric_base|add:".network.eth0.receive.byte_count),-1)&target=nonNegativeDerivative("|add:metric_base|add:".network.eth0.transmit.byte_count)" %}
+{% include "main/graphite_graph.html" %}
+{% endwith %}
+
+<h3>Free Mem</h3>
+{% with metric=metric_base|add:".memory.MemFree.percent" %}
 {% include "main/graphite_graph.html" %}
 {% endwith %}
 

--- a/plexus/templates/main/server_graphs.html
+++ b/plexus/templates/main/server_graphs.html
@@ -1,0 +1,30 @@
+{% with metric_base="ccnmtl.server."|add:graphite_name %}
+
+<h3>Load Avg</h3>
+{% with metric=metric_base|add:".cpu.load_average.1_minute" %}
+{% include "main/graphite_graph.html" %}
+{% endwith %}
+<h3>Free Mem</h3>
+{% with metric=metric_base|add:".memory.MemFree.percent" %}
+{% include "main/graphite_graph.html" %}
+{% endwith %}
+
+<h3>Eth0 in + Eth0 out</h3>
+{% with metric="nonNegativeDerivative("|add:metric_base|add:".network.eth0.receive.byte_count)&target=nonNegativeDerivative("|add:metric_base|add:".network.eth0.transmit.byte_count)" %}
+{% include "main/graphite_graph.html" %}
+{% endwith %}
+
+<h3>Swap in + out</h3>
+{% with metric="nonNegativeDerivative("|add:metric_base|add:".vmstat.swap.in)&target=nonNegativeDerivative("|add:metric_base|add:".vmstat.swap.out)" %}
+{% include "main/graphite_graph.html" %}
+{% endwith %}
+
+<h3>Disk Available (%)</h3>
+{% with ymax="&yMax=100.0" ymin="&yMin=0.0" %}
+{% with metric="asPercent("|add:metric_base|add:".disk.usage.available,"|add:metric_base|add:".disk.usage.total)&target=scale(offset(asPercent("|add:metric_base|add:".disk.inode.used,"|add:metric_base|add:".disk.inode.total),-100),-1)" %}
+{% include "main/graphite_graph.html" %}
+{% endwith %}
+{% endwith %}
+
+{% endwith %}
+


### PR DESCRIPTION
The realtime cubism.js stuff is neat and looks impressive, but after living with it for a while now, I'm feeling like I really prefer the simpler plain old static graphite image graphs when it comes to actually seeing anomalies and trends quickly.

This converts the graphs on the server detail page. I'll do application graphs in a bit.