### PR TITLE
Add back root path to nav options

### DIFF
--- a/plexus/templates/base.html
+++ b/plexus/templates/base.html
@@ -45,9 +45,9 @@
   <!-- Collect the nav links, forms, and other content for toggling -->
   <div class="collapse navbar-collapse navbar-ex1-collapse">
     <ul class="nav navbar-nav">
-			<li><a href="#servers">servers</a></li>
-			<li><a href="#aliases">aliases</a></li>
-			<li><a href="#applications">applications</a></li>
+			<li><a href="/#servers">servers</a></li>
+			<li><a href="/#aliases">aliases</a></li>
+			<li><a href="/#applications">applications</a></li>
       {% block topnavbarleftitems %}{% endblock %}
     </ul>
 


### PR DESCRIPTION
Sorry, I messed this up. We need the `/` here when not on the main page.