### PR TITLE
Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+ve
+*.pyc
+reports
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ media/CACHE
 reports/
 config.json
 node_modules/
+wheelhouse

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ccnmtl/django.base
+ADD wheelhouse /wheelhouse
+RUN /ve/bin/pip install --no-index -f /wheelhouse -r /wheelhouse/requirements.txt \
+&& rm -rf /wheelhouse
+WORKDIR /app
+COPY . /app/
+RUN /ve/bin/flake8 /app/plexus/ --max-complexity=8
+RUN /ve/bin/python manage.py test
+EXPOSE 8000
+ADD docker-run.sh /run.sh
+ENV APP plexus
+ENTRYPOINT ["/run.sh"]
+CMD ["run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+db:
+  image: postgres
+web:
+  image: ccnmtl/plexus
+  environment:
+    - SETTINGS=settings_compose
+  command: run
+  volumes:
+    - .:/app/
+  ports:
+    - "8000:8000"
+  links:
+    - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ web:
   image: ccnmtl/plexus
   environment:
     - SETTINGS=settings_compose
-  command: run
+  command: manage runserver 0.0.0.0:8000
   volumes:
     - .:/app/
   ports:

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+cd /app/
+
+if [[ "$SETTINGS" ]]; then
+		export DJANGO_SETTINGS_MODULE="$APP.$SETTINGS"
+else
+		export DJANGO_SETTINGS_MODULE="$APP.settings_docker"
+fi
+
+if [ "$1" == "migrate" ]; then
+		exec /ve/bin/python manage.py migrate --noinput
+fi
+
+if [ "$1" == "collectstatic" ]; then
+		exec /ve/bin/python manage.py collectstatic --noinput
+fi
+
+if [ "$1" == "compress" ]; then
+		exec /ve/bin/python manage.py compress
+fi
+
+if [ "$1" == "shell" ]; then
+		exec /ve/bin/python manage.py shell
+fi
+
+if [ "$1" == "worker" ]; then
+		exec /ve/bin/python manage.py celery worker
+fi
+
+if [ "$1" == "beat" ]; then
+		exec /ve/bin/python manage.py celery beat
+fi
+
+# run arbitrary commands
+if [ "$1" == "manage" ]; then
+		shift
+		exec /ve/bin/python manage.py "$@"
+fi
+
+
+if [ "$1" == "run" ]; then
+		exec /ve/bin/gunicorn --env \
+				 DJANGO_SETTINGS_MODULE=$DJANGO_SETTINGS_MODULE \
+				 $APP.wsgi:application -b 0.0.0.0:8000 -w 3 \
+				 --access-logfile=- --error-logfile=-
+fi

--- a/plexus/settings_compose.py
+++ b/plexus/settings_compose.py
@@ -1,0 +1,21 @@
+# flake8: noqa
+from settings_shared import *
+
+DEBUG = True
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'postgres',
+        'USER': 'postgres',
+        'HOST': 'db',
+        'PORT': 5432,
+        'ATOMIC_REQUESTS': True,
+    }
+}
+
+EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
+
+try:
+    from local_settings import *
+except ImportError:
+    pass

--- a/plexus/settings_docker.py
+++ b/plexus/settings_docker.py
@@ -1,0 +1,86 @@
+# flake8: noqa
+from settings_shared import *
+
+# required settings:
+SECRET_KEY = os.environ['SECRET_KEY']
+BROKER_URL = os.environ['BROKER_URL']
+
+# optional/defaulted settings
+DB_NAME = os.environ.get('DB_NAME', app)
+DB_HOST = os.environ.get(
+    'DB_HOST',
+    os.environ.get('POSTGRESQL_PORT_5432_TCP_ADDR', ''))
+DB_PORT = int(
+    os.environ.get(
+        'DB_PORT',
+        os.environ.get('POSTGRESQL_PORT_54342_TCP_PORT', 5432)))
+DB_USER = os.environ.get('DB_USER', '')
+DB_PASSWORD = os.environ.get('DB_PASSWORD', '')
+
+AWS_S3_CUSTOM_DOMAIN = os.environ.get('AWS_S3_CUSTOM_DOMAIN', '')
+AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME', '')
+AWS_ACCESS_KEY = os.environ.get('AWS_ACCESS_KEY', '')
+AWS_SECRET_KEY = os.environ.get('AWS_SECRET_KEY', '')
+AWS_ACCESS_KEY_ID = AWS_ACCESS_KEY
+AWS_SECRET_ACCESS_KEY = AWS_SECRET_KEY
+
+RAVEN_DSN = os.environ.get('RAVEN_DSN', '')
+
+if 'ALLOWED_HOSTS' in os.environ:
+    ALLOWED_HOSTS = os.environ['ALLOWED_HOSTS'].split(',')
+
+TIME_ZONE = os.environ.get('TIME_ZONE', 'America/New_York')
+
+EMAIL_HOST = os.environ.get(
+    'EMAIL_HOST',
+    os.environ.get('POSTFIX_PORT_25_TCP_ADDR', 'localhost'))
+EMAIL_PORT = os.environ.get(
+    'EMAIL_PORT',
+    os.environ.get('POSTFIX_PORT_25_TCP_PORT', 25))
+
+SERVER_EMAIL = os.environ.get('SERVER_EMAIL', app + "@thraxil.org")
+
+# -------------------------------------------
+
+DEBUG = False
+TEMPLATE_DEBUG = DEBUG
+
+TEMPLATE_DIRS = (
+    os.path.join(base, "templates"),
+)
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': DB_NAME,
+        'HOST': DB_HOST,
+        'PORT': DB_PORT,
+        'USER': DB_USER,
+        'PASSWORD': DB_PASSWORD,
+        'ATOMIC_REQUESTS': True,
+        }
+}
+
+if AWS_S3_CUSTOM_DOMAIN:
+    AWS_PRELOAD_METADATA = True
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+    S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
+    # static data, e.g. css, js, etc.
+    STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
+    STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
+    COMPRESS_ENABLED = True
+    COMPRESS_OFFLINE = True
+    COMPRESS_ROOT = STATIC_ROOT
+    COMPRESS_URL = STATIC_URL
+    COMPRESS_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
+
+if RAVEN_DSN and 'migrate' not in sys.argv:
+    INSTALLED_APPS.append('raven.contrib.django.raven_compat')
+    RAVEN_CONFIG = {
+        'dsn': RAVEN_DSN,
+    }
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+}

--- a/plexus/settings_docker.py
+++ b/plexus/settings_docker.py
@@ -38,7 +38,8 @@ EMAIL_PORT = os.environ.get(
     'EMAIL_PORT',
     os.environ.get('POSTFIX_PORT_25_TCP_PORT', 25))
 
-SERVER_EMAIL = os.environ.get('SERVER_EMAIL', app + "@thraxil.org")
+SERVER_EMAIL = os.environ.get('SERVER_EMAIL',
+                              app + "@" + app + ".ccnmtl.columbia.edu")
 
 # -------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--index-url https://pypi.ccnmtl.columbia.edu/
 Django==1.8.6
 httplib2==0.9.2
 restclient==0.11.0
@@ -10,6 +11,7 @@ statsd==3.1
 BeautifulSoup==3.2.1
 cssselect==0.9.1
 lxml==3.4.4
+funcsigs==0.4
 sure==1.2.24
 ipdb==0.8.1
 traitlets==4.0.0


### PR DESCRIPTION
I'm improving and tweaking each time I do one of these. Notable in this one:

* basing off the ccnmtl/django.base+build

* new 'docker-run.sh' that makes it easier to work with. Uses an `ENTRYPOINT` to dispatch different commands. So you can do

```
$ docker run -e [... set required env variables ...] ccnmtl/plexus
```

and it will run the default gunicorn, but you can also do:

    $ docker run -e [...] ccnmtl/plexus migrate
    $ docker run -e [...] ccnmtl/plexus collectstatic
    $ docker run -e [...] ccnmtl/plexus compress

which is important so we can do those steps independently on deploys. Or you can do:

    $ docker run -it -e [...] ccnmtl/plexus shell

to get a shell or

    $ docker run -it -e [...] ccnmtl/plexus manage any_other_manage_command --with-args

To run any other arbitrary manage.py command inside the docker container. (Very useful for something like `migrate some_app --fake`)

Like before, it defaults to `settings_docker`, which pulls everything out of environment variables. You can also set the `$SETTINGS` environment variable though to override it. See `docker-compose.yml` for
an example.

The `docker-run.sh` file is also not specific to plexus. It can be copied as-is into other projects. It just expects an `$APP` variable set in the Dockerfile to tell it which application it is running.