### PR TITLE
Remove django-indexer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,6 @@ pyOpenSSL==0.15.1
 ndg-httpsclient==0.4.0
 
 djangowind==0.14.1
-django-indexer==0.3.0
 django-paging==0.2.5
 django-appconf==1.0.1
 django_compressor==1.5


### PR DESCRIPTION
It doesn't look like plexus is using this