### PR TITLE
Add Grainlog endpoint

### DIFF
--- a/plexus/grainlog/models.py
+++ b/plexus/grainlog/models.py
@@ -1,7 +1,36 @@
 from django.db import models
 
 
+MAX_LOGS = 10  # convert this to a django setting later
+
+
+class GrainLogManager(models.Manager):
+    def create_grainlog(self, sha1, payload=""):
+        """ create new one. return it (or an existing one)
+
+        but don't enter duplicates (in a row) and don't allow more than
+        MAX entries total (deleting oldest to make room)"""
+        r = self.all()
+        if r.exists() and r.first().sha1 == sha1:
+            # don't duplicate the most recent
+            return r.first()
+
+        gl = GrainLog(sha1=sha1, payload=payload)
+        gl.save()
+        self.limit_entries()
+        return gl
+
+    def limit_entries(self):
+        for gl in self.all()[MAX_LOGS:]:
+            gl.delete()
+
+
 class GrainLog(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     sha1 = models.TextField(blank=True, default='', db_index=True)
     payload = models.TextField(blank=True, default='')
+
+    objects = GrainLogManager()
+
+    class Meta:
+        ordering = ['-created']

--- a/plexus/grainlog/models.py
+++ b/plexus/grainlog/models.py
@@ -1,7 +1,5 @@
 from django.db import models
-
-
-MAX_LOGS = 10  # convert this to a django setting later
+from django.conf import settings
 
 
 class GrainLogManager(models.Manager):
@@ -21,7 +19,7 @@ class GrainLogManager(models.Manager):
         return gl
 
     def limit_entries(self):
-        for gl in self.all()[MAX_LOGS:]:
+        for gl in self.all()[settings.MAX_GRAINLOGS:]:
             gl.delete()
 
 

--- a/plexus/grainlog/tests/factories.py
+++ b/plexus/grainlog/tests/factories.py
@@ -1,0 +1,10 @@
+import factory
+from plexus.grainlog.models import GrainLog
+
+
+class GrainLogFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = GrainLog
+
+    sha1 = 'asdfasdfasdfasdf'
+    payload = '{"foo": "bar"}'

--- a/plexus/grainlog/tests/test_models.py
+++ b/plexus/grainlog/tests/test_models.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+from .factories import GrainLogFactory
+from plexus.grainlog.models import GrainLog, MAX_LOGS
+
+
+class TestGrainLog(TestCase):
+    def test_trivial(self):
+        gl = GrainLogFactory()
+        self.assertIsNotNone(gl)
+
+
+class TestGrainLogManager(TestCase):
+    def test_create_grainlog_simple(self):
+        gl = GrainLog.objects.create_grainlog(sha1='foo', payload='bar')
+        self.assertEqual(gl.sha1, 'foo')
+        self.assertEqual(gl.payload, 'bar')
+
+    def test_create_grainlog_no_duplicate(self):
+        GrainLog.objects.create_grainlog(sha1='abcd')
+        self.assertEqual(GrainLog.objects.all().count(), 1)
+        GrainLog.objects.create_grainlog(sha1='abcd')
+        self.assertEqual(GrainLog.objects.all().count(), 1)
+        GrainLog.objects.create_grainlog(sha1='efgh')
+        self.assertEqual(GrainLog.objects.all().count(), 2)
+
+    def test_create_grainlog_no_limit_number(self):
+        # all good up to the max
+        for i in range(MAX_LOGS):
+            GrainLog.objects.create_grainlog(sha1=str(i))
+            self.assertEqual(GrainLog.objects.all().count(), i + 1)
+        # the first one inserted should still be there
+        self.assertEqual(GrainLog.objects.filter(sha1='0').count(), 1)
+        # but now it should clear out old ones
+        max_sha1 = str(MAX_LOGS + 1)
+        GrainLog.objects.create_grainlog(sha1=max_sha1)
+        self.assertEqual(GrainLog.objects.all().count(), MAX_LOGS)
+        # our most recent should be in there
+        self.assertEqual(GrainLog.objects.filter(sha1=max_sha1).count(), 1)
+        # but the earliest should be gone now
+        self.assertEqual(GrainLog.objects.filter(sha1='0').count(), 0)

--- a/plexus/grainlog/tests/test_models.py
+++ b/plexus/grainlog/tests/test_models.py
@@ -1,6 +1,7 @@
+from django.conf import settings
 from django.test import TestCase
 from .factories import GrainLogFactory
-from plexus.grainlog.models import GrainLog, MAX_LOGS
+from plexus.grainlog.models import GrainLog
 
 
 class TestGrainLog(TestCase):
@@ -25,15 +26,16 @@ class TestGrainLogManager(TestCase):
 
     def test_create_grainlog_no_limit_number(self):
         # all good up to the max
-        for i in range(MAX_LOGS):
+        for i in range(settings.MAX_GRAINLOGS):
             GrainLog.objects.create_grainlog(sha1=str(i))
             self.assertEqual(GrainLog.objects.all().count(), i + 1)
         # the first one inserted should still be there
         self.assertEqual(GrainLog.objects.filter(sha1='0').count(), 1)
         # but now it should clear out old ones
-        max_sha1 = str(MAX_LOGS + 1)
+        max_sha1 = str(settings.MAX_GRAINLOGS + 1)
         GrainLog.objects.create_grainlog(sha1=max_sha1)
-        self.assertEqual(GrainLog.objects.all().count(), MAX_LOGS)
+        self.assertEqual(GrainLog.objects.all().count(),
+                         settings.MAX_GRAINLOGS)
         # our most recent should be in there
         self.assertEqual(GrainLog.objects.filter(sha1=max_sha1).count(), 1)
         # but the earliest should be gone now

--- a/plexus/grainlog/tests/test_views.py
+++ b/plexus/grainlog/tests/test_views.py
@@ -1,0 +1,33 @@
+from django.contrib.auth.models import AnonymousUser
+from django.core.urlresolvers import reverse
+from django.test import TestCase, RequestFactory
+from plexus.grainlog.views import GrainLogListView, GrainLogDetailView
+from .factories import GrainLogFactory
+
+
+class ViewTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.anon = AnonymousUser()
+
+
+class GrainLogListViewTest(ViewTest):
+    def test_get(self):
+        gl = GrainLogFactory()
+        request = self.factory.get(reverse('grainlog-list'))
+        request.user = self.anon
+        response = GrainLogListView.as_view()(request)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(gl in response.context_data['object_list'])
+        self.assertTrue(gl.sha1 in response.rendered_content)
+
+
+class GrainLogDetailViewTest(ViewTest):
+    def test_get(self):
+        gl = GrainLogFactory()
+        request = self.factory.get(reverse('grainlog-detail', args=[gl.id]))
+        request.user = self.anon
+        response = GrainLogDetailView.as_view()(request, pk=gl.id)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context_data['object'] == gl)
+        self.assertTrue(gl.sha1 in response.rendered_content)

--- a/plexus/grainlog/tests/test_views.py
+++ b/plexus/grainlog/tests/test_views.py
@@ -20,7 +20,8 @@ class GrainLogListViewTest(ViewTest):
         response = GrainLogListView.as_view()(request)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(gl in response.context_data['object_list'])
-        self.assertTrue(gl.sha1 in response.rendered_content)
+        self.assertTrue(reverse('grainlog-detail', args=[gl.id])
+                        in response.rendered_content)
 
     def test_post(self):
         request = self.factory.post(reverse('grainlog-list'))

--- a/plexus/grainlog/tests/test_views.py
+++ b/plexus/grainlog/tests/test_views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import AnonymousUser
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.urlresolvers import reverse
 from django.test import TestCase, RequestFactory
 from plexus.grainlog.views import GrainLogListView, GrainLogDetailView
@@ -20,6 +21,15 @@ class GrainLogListViewTest(ViewTest):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(gl in response.context_data['object_list'])
         self.assertTrue(gl.sha1 in response.rendered_content)
+
+    def test_post(self):
+        request = self.factory.post(reverse('grainlog-list'))
+        with open('test_data/grains.json') as f:
+            request.FILES['payload'] = SimpleUploadedFile("grains.json",
+                                                          f.read())
+            request.user = self.anon
+            response = GrainLogListView.as_view()(request)
+            self.assertEqual(response.status_code, 302)
 
 
 class GrainLogDetailViewTest(ViewTest):

--- a/plexus/grainlog/urls.py
+++ b/plexus/grainlog/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url
+
+from .views import GrainLogListView, GrainLogDetailView
+
+urlpatterns = [
+    url(r'^$', GrainLogListView.as_view(), name='grainlog-list'),
+    url(r'^(?P<pk>\d+)/$', GrainLogDetailView.as_view(),
+        name='grainlog-detail'),
+]

--- a/plexus/grainlog/views.py
+++ b/plexus/grainlog/views.py
@@ -1,9 +1,27 @@
+import hashlib
+
+from django.core.urlresolvers import reverse
+from django.http.response import HttpResponseBadRequest, HttpResponseRedirect
 from django.views.generic import ListView, DetailView
 from plexus.grainlog.models import GrainLog
 
 
 class GrainLogListView(ListView):
     model = GrainLog
+
+    def post(self, request, **kwargs):
+        f = request.FILES.get('payload', None)
+        if f is None:
+            return HttpResponseBadRequest()
+
+        # typical grainlog uploads are around 200k, which
+        # is small enough that I think we can get away
+        # with just turning it into a string in memory
+        payload = ''.join(list(f.chunks()))
+
+        sha1 = hashlib.sha1(payload).hexdigest()
+        gl = self.model.objects.create_grainlog(sha1=sha1, payload=payload)
+        return HttpResponseRedirect(reverse('grainlog-detail', args=[gl.id]))
 
 
 class GrainLogDetailView(DetailView):

--- a/plexus/grainlog/views.py
+++ b/plexus/grainlog/views.py
@@ -1,0 +1,10 @@
+from django.views.generic import ListView, DetailView
+from plexus.grainlog.models import GrainLog
+
+
+class GrainLogListView(ListView):
+    model = GrainLog
+
+
+class GrainLogDetailView(DetailView):
+    model = GrainLog

--- a/plexus/settings_shared.py
+++ b/plexus/settings_shared.py
@@ -8,7 +8,7 @@ base = os.path.dirname(__file__)
 
 locals().update(common(project=project, base=base))
 
-PROJECT_APPS = ['plexus.main', ]
+PROJECT_APPS = ['plexus.main', 'plexus.grainlog']
 USE_TZ = True
 
 TEMPLATE_CONTEXT_PROCESSORS += [  # noqa
@@ -26,3 +26,5 @@ INSTALLED_APPS += [  # noqa
 
 HOSTMASTER_EMAIL = "hostmaster@columbia.edu"
 SYSADMIN_LIST_EMAIL = "ccnmtl-sysadmin@columbia.edu"
+
+MAX_GRAINLOGS = 10

--- a/plexus/templates/base.html
+++ b/plexus/templates/base.html
@@ -49,6 +49,7 @@
 			<li><a href="/#aliases">aliases</a></li>
 			<li><a href="/#applications">applications</a></li>
 			<li><a href="{% url 'dashboard-index' %}">dashboards</a></li>
+      <li><a href="{% url 'grainlog-list' %}">grainlogs</a></li>
       {% block topnavbarleftitems %}{% endblock %}
     </ul>
 

--- a/plexus/templates/grainlog/grainlog_detail.html
+++ b/plexus/templates/grainlog/grainlog_detail.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
 {% block pagetitle %}
-    <h2>{{object.created|date}} - {{object.sha1}}</h2>
+    <h2>{{object.created}}</h2>
 {% endblock %}
 
 {% block content %}
-
+    <p>SHA1: {{object.sha1}}</p>
     <pre>
 {{object.payload}}
     </pre>

--- a/plexus/templates/grainlog/grainlog_detail.html
+++ b/plexus/templates/grainlog/grainlog_detail.html
@@ -1,7 +1,9 @@
 {% extends 'base.html' %}
-{% block content %}
-
+{% block pagetitle %}
     <h2>{{object.created|date}} - {{object.sha1}}</h2>
+{% endblock %}
+
+{% block content %}
 
     <pre>
 {{object.payload}}

--- a/plexus/templates/grainlog/grainlog_detail.html
+++ b/plexus/templates/grainlog/grainlog_detail.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+
+    <h2>{{object.created|date}} - {{object.sha1}}</h2>
+
+    <pre>
+{{object.payload}}
+    </pre>
+    
+{% endblock %}

--- a/plexus/templates/grainlog/grainlog_list.html
+++ b/plexus/templates/grainlog/grainlog_list.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1>Grain Logs</h1>
+<ul>
+{% for grainlog in object_list %}
+    <li><a href="{% url 'grainlog-detail' grainlog.id %}">{{ grainlog.created|date }} - {{ grainlog.sha1 }}</a></li>
+{% empty %}
+    <li>No grainlogs yet.</li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/plexus/templates/grainlog/grainlog_list.html
+++ b/plexus/templates/grainlog/grainlog_list.html
@@ -3,7 +3,7 @@
 <h1>Grain Logs</h1>
 <ul>
 {% for grainlog in object_list %}
-    <li><a href="{% url 'grainlog-detail' grainlog.id %}">{{ grainlog.created|date }} - {{ grainlog.sha1 }}</a></li>
+    <li><a href="{% url 'grainlog-detail' grainlog.id %}">{{ grainlog.created }}</li>
 {% empty %}
     <li>No grainlogs yet.</li>
 {% endfor %}

--- a/plexus/urls.py
+++ b/plexus/urls.py
@@ -117,6 +117,7 @@ urlpatterns = patterns(
     (r'^stats/$', TemplateView.as_view(template_name="stats.html")),
     (r'^stats/auth/$', TemplateView.as_view(template_name="auth_stats.html")),
     (r'smoketest/', include('smoketest.urls')),
+    (r'grainlogs/', include('plexus.grainlog.urls')),
     (r'^uploads/(?P<path>.*)$',
      'django.views.static.serve',
      {'document_root': settings.MEDIA_ROOT}),

--- a/test_data/grains.json
+++ b/test_data/grains.json
@@ -1,0 +1,6003 @@
+{
+    "servers": [
+        {
+            "jupiter": {
+                "biosversion": "4.2.amazon", 
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "3.13.0-48-generic", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages/PILcompat"
+                ], 
+                "serialnumber": "ec2a6b22-43c7-1703-f157-d86fb5518c2b", 
+                "ip_interfaces": {
+                    "lxcbr0": [
+                        "10.0.3.1", 
+                        "fe80::f09f:67ff:fefc:9708"
+                    ], 
+                    "vethb931d77": [
+                        "fe80::4462:a7ff:fe19:f4cc"
+                    ], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "vethe90aa9d": [
+                        "fe80::9cc9:76ff:fe1c:19f6"
+                    ], 
+                    "docker0": [
+                        "172.17.42.1", 
+                        "fe80::5484:7aff:fefe:9799"
+                    ], 
+                    "veth0d18fb6": [
+                        "fe80::e84e:59ff:fe23:19ae"
+                    ], 
+                    "eth0": [
+                        "172.31.17.250", 
+                        "fe80::83c:39ff:feb3:7835"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 2000, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "xvda"
+                ], 
+                "mdadm": [], 
+                "id": "jupiter", 
+                "ipv4": [
+                    "10.0.3.1", 
+                    "127.0.0.1", 
+                    "172.17.42.1", 
+                    "172.31.17.250"
+                ], 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "lsb_distrib_description": "Ubuntu 14.04.3 LTS", 
+                "ip6_interfaces": {
+                    "lxcbr0": [
+                        "fe80::f09f:67ff:fefc:9708"
+                    ], 
+                    "vethb931d77": [
+                        "fe80::4462:a7ff:fe19:f4cc"
+                    ], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "vethe90aa9d": [
+                        "fe80::9cc9:76ff:fe1c:19f6"
+                    ], 
+                    "docker0": [
+                        "fe80::5484:7aff:fefe:9799"
+                    ], 
+                    "veth0d18fb6": [
+                        "fe80::e84e:59ff:fe23:19ae"
+                    ], 
+                    "eth0": [
+                        "fe80::83c:39ff:feb3:7835"
+                    ]
+                }, 
+                "num_cpus": 1, 
+                "apps": [
+                    "frontdesk"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "lxcbr0": [
+                        "10.0.3.1"
+                    ], 
+                    "vethb931d77": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "vethe90aa9d": [], 
+                    "docker0": [
+                        "172.17.42.1"
+                    ], 
+                    "veth0d18fb6": [], 
+                    "eth0": [
+                        "172.31.17.250"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "::1", 
+                    "fe80::4462:a7ff:fe19:f4cc", 
+                    "fe80::5484:7aff:fefe:9799", 
+                    "fe80::83c:39ff:feb3:7835", 
+                    "fe80::9cc9:76ff:fe1c:19f6", 
+                    "fe80::e84e:59ff:fe23:19ae", 
+                    "fe80::f09f:67ff:fefc:9708"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "vme", 
+                    "de", 
+                    "pse", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "mce", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "mtrr", 
+                    "pge", 
+                    "mca", 
+                    "cmov", 
+                    "pat", 
+                    "pse36", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "rdtscp", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "xtopology", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "pcid", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "x2apic", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "xsaveopt", 
+                    "fsgsbase", 
+                    "smep", 
+                    "erms"
+                ], 
+                "hwaddr_interfaces": {
+                    "lxcbr0": "f2:9f:67:fc:97:08", 
+                    "vethb931d77": "46:62:a7:19:f4:cc", 
+                    "lo": "00:00:00:00:00:00", 
+                    "vethe90aa9d": "9e:c9:76:1c:19:f6", 
+                    "docker0": "56:84:7a:fe:97:99", 
+                    "veth0d18fb6": "ea:4e:59:23:19:ae", 
+                    "eth0": "0a:3c:39:b3:78:35"
+                }, 
+                "localhost": "jupiter.ccnmtl.columbia.edu", 
+                "location": "ec2", 
+                "fqdn_ip4": [], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "jupiter.ccnmtl.columbia.edu", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "server_id": 1728071316, 
+                "biosreleasedate": "05/06/2015", 
+                "host": "jupiter", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "manufacturer": "Xen", 
+                "num_gpus": 1, 
+                "roles": [
+                    "jenkins", 
+                    "docker"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz", 
+                "fqdn": "jupiter.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "productname": "HVM domU", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [
+                    {
+                        "model": "GD 5446", 
+                        "vendor": "unknown"
+                    }
+                ], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "e953ce35510a043907b5de705512a156", 
+                "os": "Ubuntu", 
+                "ec2": true
+            }
+        }, 
+        {
+            "rabbit": {
+                "biosversion": "4.2.amazon", 
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "3.13.0-48-generic", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "serialnumber": "ec2c3f19-5b3c-4b63-7da3-7fbeb4aec0e8", 
+                "ip_interfaces": {
+                    "lxcbr0": [
+                        "10.0.3.1", 
+                        "fe80::8441:62ff:fe84:8e38"
+                    ], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "vethfaa836e": [
+                        "fe80::e824:2dff:fe3a:9c3d"
+                    ], 
+                    "veth8e73a4b": [
+                        "fe80::a82d:baff:fec6:2dd0"
+                    ], 
+                    "docker0": [
+                        "172.17.0.1", 
+                        "fe80::42:dfff:fe9e:5acd"
+                    ], 
+                    "vethf6802f3": [
+                        "fe80::ac41:13ff:fe3b:ee57"
+                    ], 
+                    "eth0": [
+                        "172.31.17.254", 
+                        "fe80::899:70ff:fe29:d8e7"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 2000, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "xvda"
+                ], 
+                "mdadm": [], 
+                "id": "rabbit", 
+                "ipv4": [
+                    "10.0.3.1", 
+                    "127.0.0.1", 
+                    "172.17.0.1", 
+                    "172.31.17.254"
+                ], 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "lsb_distrib_description": "Ubuntu 14.04.2 LTS", 
+                "ip6_interfaces": {
+                    "lxcbr0": [
+                        "fe80::8441:62ff:fe84:8e38"
+                    ], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "vethfaa836e": [
+                        "fe80::e824:2dff:fe3a:9c3d"
+                    ], 
+                    "veth8e73a4b": [
+                        "fe80::a82d:baff:fec6:2dd0"
+                    ], 
+                    "docker0": [
+                        "fe80::42:dfff:fe9e:5acd"
+                    ], 
+                    "vethf6802f3": [
+                        "fe80::ac41:13ff:fe3b:ee57"
+                    ], 
+                    "eth0": [
+                        "fe80::899:70ff:fe29:d8e7"
+                    ]
+                }, 
+                "num_cpus": 1, 
+                "apps": [
+                    "rolf"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "lxcbr0": [
+                        "10.0.3.1"
+                    ], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "vethfaa836e": [], 
+                    "veth8e73a4b": [], 
+                    "docker0": [
+                        "172.17.0.1"
+                    ], 
+                    "vethf6802f3": [], 
+                    "eth0": [
+                        "172.31.17.254"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "::1", 
+                    "fe80::42:dfff:fe9e:5acd", 
+                    "fe80::8441:62ff:fe84:8e38", 
+                    "fe80::899:70ff:fe29:d8e7", 
+                    "fe80::a82d:baff:fec6:2dd0", 
+                    "fe80::ac41:13ff:fe3b:ee57", 
+                    "fe80::e824:2dff:fe3a:9c3d"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "vme", 
+                    "de", 
+                    "pse", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "mce", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "mtrr", 
+                    "pge", 
+                    "mca", 
+                    "cmov", 
+                    "pat", 
+                    "pse36", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "rdtscp", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "xtopology", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "fma", 
+                    "cx16", 
+                    "pcid", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "x2apic", 
+                    "movbe", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "abm", 
+                    "xsaveopt", 
+                    "fsgsbase", 
+                    "bmi1", 
+                    "avx2", 
+                    "smep", 
+                    "bmi2", 
+                    "erms", 
+                    "invpcid"
+                ], 
+                "hwaddr_interfaces": {
+                    "lxcbr0": "86:41:62:84:8e:38", 
+                    "lo": "00:00:00:00:00:00", 
+                    "vethfaa836e": "ea:24:2d:3a:9c:3d", 
+                    "veth8e73a4b": "aa:2d:ba:c6:2d:d0", 
+                    "docker0": "02:42:df:9e:5a:cd", 
+                    "vethf6802f3": "ae:41:13:3b:ee:57", 
+                    "eth0": "0a:99:70:29:d8:e7"
+                }, 
+                "localhost": "rabbit.ccnmtl.columbia.edu", 
+                "location": "ec2", 
+                "fqdn_ip4": [], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "ip-172-31-17-254", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "server_id": 786299222, 
+                "biosreleasedate": "12/07/2015", 
+                "host": "rabbit", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "manufacturer": "Xen", 
+                "num_gpus": 1, 
+                "roles": [
+                    "django", 
+                    "python", 
+                    "docker"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz", 
+                "fqdn": "rabbit.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "productname": "HVM domU", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [
+                    {
+                        "model": "GD 5446", 
+                        "vendor": "unknown"
+                    }
+                ], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "e953ce35510a043907b5de705512a156", 
+                "os": "Ubuntu", 
+                "ec2": true
+            }
+        }, 
+        {
+            "nectar": {
+                "biosversion": "4.2.amazon", 
+                "kernel": "Linux", 
+                "domain": "compute-1.amazonaws.com", 
+                "biosreleasedate": "05/06/2015", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "3.13.0-48-generic", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "serialnumber": "ec25148c-84f8-a6fb-91d1-0301b94dd5ae", 
+                "ip_interfaces": {
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "172.31.17.251", 
+                        "fe80::803:beff:feb6:abfb"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 992, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "xvda"
+                ], 
+                "mdadm": [], 
+                "id": "nectar", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "lsb_distrib_description": "Ubuntu 14.04.2 LTS", 
+                "ip6_interfaces": {
+                    "lo": [
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "fe80::803:beff:feb6:abfb"
+                    ]
+                }, 
+                "num_cpus": 1, 
+                "hwaddr_interfaces": {
+                    "lo": "00:00:00:00:00:00", 
+                    "eth0": "0a:03:be:b6:ab:fb"
+                }, 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "eth0": [
+                        "172.31.17.251"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "::1", 
+                    "fe80::803:beff:feb6:abfb"
+                ], 
+                "role": [
+                    "bastion"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "vme", 
+                    "de", 
+                    "pse", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "mce", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "mtrr", 
+                    "pge", 
+                    "mca", 
+                    "cmov", 
+                    "pat", 
+                    "pse36", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "rdtscp", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "xtopology", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "pcid", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "x2apic", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "xsaveopt", 
+                    "fsgsbase", 
+                    "smep", 
+                    "erms"
+                ], 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "172.31.17.251"
+                ], 
+                "localhost": "nectar.ccnmtl.columbia.edu", 
+                "location": "ec2", 
+                "fqdn_ip4": [
+                    "172.31.17.251"
+                ], 
+                "shell": "/bin/sh", 
+                "nodename": "nectar.ccnmtl.columbia.edu", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "server_id": 254134373, 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "host": "nectar", 
+                "os_family": "Debian", 
+                "proxy": [
+                    "jenkins.nginx", 
+                    "frontdesk", 
+                    "jenkins", 
+                    "pypi", 
+                    "gitweb", 
+                    "capsim", 
+                    "forest", 
+                    "dmt", 
+                    "rolf", 
+                    "polarexplorer", 
+                    "carr", 
+                    "ccdb", 
+                    "pedialabsnew"
+                ], 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "manufacturer": "Xen", 
+                "num_gpus": 1, 
+                "roles": [
+                    "nginx", 
+                    "haproxy", 
+                    "bastion"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz", 
+                "fqdn": "nectar.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "productname": "HVM domU", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [
+                    {
+                        "model": "GD 5446", 
+                        "vendor": "unknown"
+                    }
+                ], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "e953ce35510a043907b5de705512a156", 
+                "os": "Ubuntu", 
+                "ec2": true
+            }
+        }, 
+        {
+            "mercury": {
+                "biosversion": "4.2.amazon", 
+                "kernel": "Linux", 
+                "domain": "compute-1.amazonaws.com", 
+                "biosreleasedate": "12/07/2015", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "3.13.0-48-generic", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "serialnumber": "ec2e70fb-4e28-eacd-c168-9e75e2d6663d", 
+                "ip_interfaces": {
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "172.31.17.253", 
+                        "fe80::817:e7ff:fee5:b603"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 992, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "xvda"
+                ], 
+                "mdadm": [], 
+                "id": "mercury", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "locale_info": {
+                    "detectedencoding": "UTF-8", 
+                    "defaultlanguage": "en_US", 
+                    "defaultencoding": "UTF-8"
+                }, 
+                "lsb_distrib_description": "Ubuntu 14.04.3 LTS", 
+                "ip6_interfaces": {
+                    "lo": [
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "fe80::817:e7ff:fee5:b603"
+                    ]
+                }, 
+                "num_cpus": 1, 
+                "hwaddr_interfaces": {
+                    "lo": "00:00:00:00:00:00", 
+                    "eth0": "0a:17:e7:e5:b6:03"
+                }, 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "eth0": [
+                        "172.31.17.253"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "::1", 
+                    "fe80::817:e7ff:fee5:b603"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "vme", 
+                    "de", 
+                    "pse", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "mce", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "mtrr", 
+                    "pge", 
+                    "mca", 
+                    "cmov", 
+                    "pat", 
+                    "pse36", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "rdtscp", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "xtopology", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "fma", 
+                    "cx16", 
+                    "pcid", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "x2apic", 
+                    "movbe", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "abm", 
+                    "xsaveopt", 
+                    "fsgsbase", 
+                    "bmi1", 
+                    "avx2", 
+                    "smep", 
+                    "bmi2", 
+                    "erms", 
+                    "invpcid"
+                ], 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "172.31.17.253"
+                ], 
+                "localhost": "mercury.ccnmtl.columbia.edu", 
+                "location": "ec2", 
+                "fqdn_ip4": [
+                    "172.31.17.253"
+                ], 
+                "shell": "/bin/sh", 
+                "nodename": "mercury.ccnmtl.columbia.edu", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "server_id": 53338912, 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "host": "mercury", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "manufacturer": "Xen", 
+                "num_gpus": 1, 
+                "roles": [
+                    "saltmaster", 
+                    "salt-cloud"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz", 
+                "fqdn": "mercury.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "productname": "HVM domU", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [
+                    {
+                        "model": "GD 5446", 
+                        "vendor": "unknown"
+                    }
+                ], 
+                "path": "/sbin:/usr/sbin:/bin:/usr/bin", 
+                "machine_id": "e953ce35510a043907b5de705512a156", 
+                "os": "Ubuntu", 
+                "ec2": true
+            }
+        }, 
+        {
+            "kang.ccnmtl.columbia.edu": {
+                "biosversion": "rel-1.8.2-0-g33fbe13 by qemu-project.org", 
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "serialnumber": "Not Specified", 
+                "ip_interfaces": {
+                    "lxcbr0": [
+                        "10.0.3.1", 
+                        "fe80::e0b1:42ff:febb:2775"
+                    ], 
+                    "gre0": [], 
+                    "docker0": [
+                        "172.17.0.1", 
+                        "fe80::42:e9ff:fefd:9f3e"
+                    ], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "ip6gre0": [], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "vethde4244d": [
+                        "fe80::5858:ceff:fe80:af5c"
+                    ], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "veth1594d01": [
+                        "fe80::1460:64ff:fe6a:9efa"
+                    ], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.136.38", 
+                        "192.168.194.158", 
+                        "2600:3c03::f03c:91ff:fe26:4aa", 
+                        "fe80::f03c:91ff:fe26:4aa"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1999, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "kang.ccnmtl.columbia.edu", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 968867552, 
+                "lsb_distrib_description": "Ubuntu 14.04.3 LTS", 
+                "ip6_interfaces": {
+                    "lxcbr0": [
+                        "fe80::e0b1:42ff:febb:2775"
+                    ], 
+                    "gre0": [], 
+                    "docker0": [
+                        "fe80::42:e9ff:fefd:9f3e"
+                    ], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "ip6gre0": [], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "vethde4244d": [
+                        "fe80::5858:ceff:fe80:af5c"
+                    ], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "veth1594d01": [
+                        "fe80::1460:64ff:fe6a:9efa"
+                    ], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "2600:3c03::f03c:91ff:fe26:4aa", 
+                        "fe80::f03c:91ff:fe26:4aa"
+                    ]
+                }, 
+                "num_cpus": 2, 
+                "linode": true, 
+                "hwaddr_interfaces": {
+                    "lxcbr0": "e2:b1:42:bb:27:75", 
+                    "gre0": "0.0.0.0", 
+                    "docker0": "02:42:e9:fd:9f:3e", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "vethde4244d": "5a:58:ce:80:af:5c", 
+                    "sit0": "0.0.0.0", 
+                    "dummy0": "5e:87:e4:31:bc:1f", 
+                    "veth1594d01": "16:60:64:6a:9e:fa", 
+                    "ip_vti0": "0.0.0.0", 
+                    "eth0": "f2:3c:91:26:04:aa"
+                }, 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "lxcbr0": [
+                        "10.0.3.1"
+                    ], 
+                    "gre0": [], 
+                    "docker0": [
+                        "172.17.0.1"
+                    ], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "ip6gre0": [], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "vethde4244d": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "veth1594d01": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.136.38", 
+                        "192.168.194.158"
+                    ]
+                }, 
+                "environment": "dev", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "ipv4": [
+                    "10.0.3.1", 
+                    "127.0.0.1", 
+                    "172.17.0.1", 
+                    "192.168.194.158", 
+                    "45.79.136.38"
+                ], 
+                "ipv6": [
+                    "2600:3c03::f03c:91ff:fe26:4aa", 
+                    "::1", 
+                    "fe80::1460:64ff:fe6a:9efa", 
+                    "fe80::42:e9ff:fefd:9f3e", 
+                    "fe80::5858:ceff:fe80:af5c", 
+                    "fe80::e0b1:42ff:febb:2775", 
+                    "fe80::f03c:91ff:fe26:4aa"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "vme", 
+                    "de", 
+                    "pse", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "mce", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "mtrr", 
+                    "pge", 
+                    "mca", 
+                    "cmov", 
+                    "pat", 
+                    "pse36", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "syscall", 
+                    "nx", 
+                    "pdpe1gb", 
+                    "rdtscp", 
+                    "lm", 
+                    "constant_tsc", 
+                    "arch_perfmon", 
+                    "rep_good", 
+                    "nopl", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "fma", 
+                    "cx16", 
+                    "pcid", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "x2apic", 
+                    "movbe", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "abm", 
+                    "arat", 
+                    "fsgsbase", 
+                    "tsc_adjust", 
+                    "bmi1", 
+                    "avx2", 
+                    "smep", 
+                    "bmi2", 
+                    "erms", 
+                    "invpcid", 
+                    "xsaveopt"
+                ], 
+                "localhost": "kang.ccnmtl.columbia.edu", 
+                "lsb_distrib_id": "Ubuntu", 
+                "fqdn_ip4": [
+                    "45.79.136.38"
+                ], 
+                "shell": "/bin/sh", 
+                "nodename": "kang.ccnmtl.columbia.edu", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "host": "kang", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "biosreleasedate": "04/01/2014", 
+                "manufacturer": "QEMU", 
+                "num_gpus": 1, 
+                "roles": [
+                    "docker", 
+                    "lamp", 
+                    "mysql-server"
+                ], 
+                "virtual": "kvm", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz", 
+                "fqdn": "kang.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "productname": "Standard PC (i440FX + PIIX, 1996)", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "gpus": [
+                    {
+                        "model": "Device 1111", 
+                        "vendor": "unknown"
+                    }
+                ], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "giant": {
+                "biosversion": "4.2.amazon", 
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "biosreleasedate": "12/07/2015", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "3.13.0-48-generic", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "serialnumber": "ec2b9426-394d-32ee-dc51-89c317661994", 
+                "ip_interfaces": {
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "172.31.17.252", 
+                        "fe80::820:67ff:fe26:7bb3"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 2000, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "xvda"
+                ], 
+                "mdadm": [], 
+                "id": "giant", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "lsb_distrib_description": "Ubuntu 14.04.2 LTS", 
+                "ip6_interfaces": {
+                    "lo": [
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "fe80::820:67ff:fe26:7bb3"
+                    ]
+                }, 
+                "num_cpus": 1, 
+                "hwaddr_interfaces": {
+                    "lo": "00:00:00:00:00:00", 
+                    "eth0": "0a:20:67:26:7b:b3"
+                }, 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "eth0": [
+                        "172.31.17.252"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "::1", 
+                    "fe80::820:67ff:fe26:7bb3"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "vme", 
+                    "de", 
+                    "pse", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "mce", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "mtrr", 
+                    "pge", 
+                    "mca", 
+                    "cmov", 
+                    "pat", 
+                    "pse36", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "rdtscp", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "xtopology", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "pcid", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "x2apic", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "xsaveopt", 
+                    "fsgsbase", 
+                    "smep", 
+                    "erms"
+                ], 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "172.31.17.252"
+                ], 
+                "localhost": "giant.ccnmtl.columbia.edu", 
+                "location": "ec2", 
+                "fqdn_ip4": [], 
+                "shell": "/bin/sh", 
+                "nodename": "giant.ccnmtl.columbia.edu", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "server_id": 172217378, 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "host": "giant", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "manufacturer": "Xen", 
+                "num_gpus": 1, 
+                "roles": [
+                    "git", 
+                    "pypi", 
+                    "watcher"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2670 v2 @ 2.50GHz", 
+                "fqdn": "giant.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "productname": "HVM domU", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [
+                    {
+                        "model": "GD 5446", 
+                        "vendor": "unknown"
+                    }
+                ], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "e953ce35510a043907b5de705512a156", 
+                "os": "Ubuntu", 
+                "ec2": true
+            }
+        }, 
+        {
+            "wolf.ccnmtl.columbia.edu": {
+                "biosversion": "MM41.88Z.0042.B03.1111072100", 
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "3.19.0-30-generic", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "serialnumber": "C07CW60YDD6L", 
+                "ip_interfaces": {
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "wlan0": [], 
+                    "eth0": [
+                        "128.59.153.237", 
+                        "fe80::c62c:3ff:fe0d:d33"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 7727, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "sda", 
+                    "dm-0", 
+                    "dm-1"
+                ], 
+                "mdadm": [], 
+                "id": "wolf.ccnmtl.columbia.edu", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 319577217, 
+                "lsb_distrib_description": "Ubuntu 14.04.3 LTS", 
+                "ip6_interfaces": {
+                    "lo": [
+                        "::1"
+                    ], 
+                    "wlan0": [], 
+                    "eth0": [
+                        "fe80::c62c:3ff:fe0d:d33"
+                    ]
+                }, 
+                "num_cpus": 2, 
+                "hwaddr_interfaces": {
+                    "lo": "00:00:00:00:00:00", 
+                    "wlan0": "60:33:4b:05:3a:6b", 
+                    "eth0": "c4:2c:03:0d:0d:33"
+                }, 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "wlan0": [], 
+                    "eth0": [
+                        "128.59.153.237"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "128.59.153.237"
+                ], 
+                "ipv6": [
+                    "::1", 
+                    "fe80::c62c:3ff:fe0d:d33"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "vme", 
+                    "de", 
+                    "pse", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "mce", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "mtrr", 
+                    "pge", 
+                    "mca", 
+                    "cmov", 
+                    "pat", 
+                    "pse36", 
+                    "clflush", 
+                    "dts", 
+                    "acpi", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "tm", 
+                    "pbe", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "arch_perfmon", 
+                    "pebs", 
+                    "bts", 
+                    "rep_good", 
+                    "nopl", 
+                    "aperfmperf", 
+                    "pni", 
+                    "dtes64", 
+                    "monitor", 
+                    "ds_cpl", 
+                    "vmx", 
+                    "smx", 
+                    "est", 
+                    "tm2", 
+                    "ssse3", 
+                    "cx16", 
+                    "xtpr", 
+                    "pdcm", 
+                    "sse4_1", 
+                    "xsave", 
+                    "lahf_lm", 
+                    "dtherm", 
+                    "tpr_shadow", 
+                    "vnmi", 
+                    "flexpriority"
+                ], 
+                "localhost": "wolf.ccnmtl.columbia.edu", 
+                "lsb_distrib_id": "Ubuntu", 
+                "fqdn_ip4": [
+                    "128.59.153.237"
+                ], 
+                "shell": "/bin/sh", 
+                "nodename": "wolf", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "host": "wolf", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "biosreleasedate": "11/07/11", 
+                "manufacturer": "Apple Inc.", 
+                "num_gpus": 1, 
+                "roles": [
+                    "backups"
+                ], 
+                "virtual": "physical", 
+                "cpu_model": "Intel(R) Core(TM)2 Duo CPU     P8800  @ 2.66GHz", 
+                "fqdn": "wolf.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "productname": "Macmini4,1", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "gpus": [
+                    {
+                        "model": "MCP89 [GeForce 320M]", 
+                        "vendor": "nvidia"
+                    }
+                ], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "9ae6dfd8ef3a5ab63347ad98561ff10b", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "desna.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "ip_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.139.5", 
+                        "192.168.196.144", 
+                        "2600:3c03::f03c:91ff:fe26:d20c", 
+                        "fe80::f03c:91ff:fe26:d20c"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1991, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "xvda", 
+                    "xvdb", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "desna.ccnmtl.columbia.edu", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 771470411, 
+                "lsb_distrib_description": "Ubuntu 14.04.3 LTS", 
+                "ip6_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "2600:3c03::f03c:91ff:fe26:d20c", 
+                        "fe80::f03c:91ff:fe26:d20c"
+                    ]
+                }, 
+                "num_cpus": 2, 
+                "linode": true, 
+                "hwaddr_interfaces": {
+                    "gre0": "0.0.0.0", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "sit0": "0.0.0.0", 
+                    "dummy0": "0a:21:82:24:89:84", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", 
+                    "ip_vti0": "0.0.0.0", 
+                    "eth0": "f2:3c:91:26:d2:0c"
+                }, 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.139.5", 
+                        "192.168.196.144"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "2600:3c03::f03c:91ff:fe26:d20c", 
+                    "::1", 
+                    "fe80::f03c:91ff:fe26:d20c"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "nonstop_tsc", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "pln", 
+                    "pts", 
+                    "dtherm", 
+                    "fsgsbase", 
+                    "erms", 
+                    "xsaveopt"
+                ], 
+                "localhost": "desna", 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "192.168.196.144", 
+                    "45.79.139.5"
+                ], 
+                "fqdn_ip4": [
+                    "45.79.139.5"
+                ], 
+                "shell": "/bin/sh", 
+                "nodename": "desna", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "host": "desna", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "mysql-server"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz", 
+                "fqdn": "desna.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "scuba.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages/PILcompat"
+                ], 
+                "ip_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "23.239.15.112", 
+                        "2600:3c03::f03c:91ff:fe50:14cd", 
+                        "fe80::f03c:91ff:fe50:14cd"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1991, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "xvda", 
+                    "xvdb", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "scuba.ccnmtl.columbia.edu", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 986636440, 
+                "lsb_distrib_description": "Ubuntu 14.04.3 LTS", 
+                "ip6_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "2600:3c03::f03c:91ff:fe50:14cd", 
+                        "fe80::f03c:91ff:fe50:14cd"
+                    ]
+                }, 
+                "num_cpus": 2, 
+                "linode": true, 
+                "apps": [
+                    "brownfield_django", 
+                    "ccdb", 
+                    "countryx", 
+                    "diabeaters", 
+                    "masivukeni", 
+                    "meaningfulconsent", 
+                    "mediamachine", 
+                    "mvsim", 
+                    "pass", 
+                    "plexus", 
+                    "pump", 
+                    "ssnm", 
+                    "tala", 
+                    "teachdentistry", 
+                    "tobaccocessation", 
+                    "uelc", 
+                    "worth2"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "23.239.15.112"
+                    ]
+                }, 
+                "environment": "staging", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "2600:3c03::f03c:91ff:fe50:14cd", 
+                    "::1", 
+                    "fe80::f03c:91ff:fe50:14cd"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "nonstop_tsc", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "pln", 
+                    "pts", 
+                    "dtherm", 
+                    "fsgsbase", 
+                    "erms", 
+                    "xsaveopt"
+                ], 
+                "localhost": "scuba.ccnmtl.columbia.edu", 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "23.239.15.112"
+                ], 
+                "fqdn_ip4": [
+                    "23.239.15.112"
+                ], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "scuba.ccnmtl.columbia.edu", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "hwaddr_interfaces": {
+                    "gre0": "0.0.0.0", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "sit0": "0.0.0.0", 
+                    "dummy0": "32:90:8e:47:4d:a9", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", 
+                    "ip_vti0": "0.0.0.0", 
+                    "eth0": "f2:3c:91:50:14:cd"
+                }, 
+                "host": "scuba", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "python"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz", 
+                "fqdn": "scuba.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "kodos.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages/PILcompat", 
+                    "/usr/lib/python2.7/dist-packages/gtk-2.0", 
+                    "/usr/lib/pymodules/python2.7", 
+                    "/usr/lib/python2.7/dist-packages/wx-2.8-gtk2-unicode"
+                ], 
+                "ip_interfaces": {
+                    "docker0": [
+                        "172.17.0.1"
+                    ], 
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.33.70.38", 
+                        "2600:3c03::f03c:91ff:fe18:e690", 
+                        "fe80::f03c:91ff:fe18:e690"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1991, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "xvda", 
+                    "xvdb", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "kodos.ccnmtl.columbia.edu", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 1384402204, 
+                "lsb_distrib_description": "Ubuntu 14.04.3 LTS", 
+                "ip6_interfaces": {
+                    "docker0": [], 
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "2600:3c03::f03c:91ff:fe18:e690", 
+                        "fe80::f03c:91ff:fe18:e690"
+                    ]
+                }, 
+                "num_cpus": 2, 
+                "linode": true, 
+                "apps": [
+                    "blackrock", 
+                    "match", 
+                    "mediathread", 
+                    "pass", 
+                    "phtc", 
+                    "wacep", 
+                    "tobaccocessation"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "docker0": [
+                        "172.17.0.1"
+                    ], 
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.33.70.38"
+                    ]
+                }, 
+                "environment": "dev", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "2600:3c03::f03c:91ff:fe18:e690", 
+                    "::1", 
+                    "fe80::f03c:91ff:fe18:e690"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "nonstop_tsc", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "pln", 
+                    "pts", 
+                    "dtherm", 
+                    "fsgsbase", 
+                    "erms", 
+                    "xsaveopt"
+                ], 
+                "localhost": "kodos.ccnmtl.columbia.edu", 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "172.17.0.1", 
+                    "45.33.70.38"
+                ], 
+                "fqdn_ip4": [
+                    "45.33.70.38"
+                ], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "kodos", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "hwaddr_interfaces": {
+                    "docker0": "02:42:ea:c5:1a:c0", 
+                    "gre0": "0.0.0.0", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "sit0": "0.0.0.0", 
+                    "dummy0": "66:c7:db:c0:15:6c", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", 
+                    "ip_vti0": "0.0.0.0", 
+                    "eth0": "f2:3c:91:18:e6:90"
+                }, 
+                "host": "kodos", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "django", 
+                    "python", 
+                    "windsock", 
+                    "nodejs"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz", 
+                "fqdn": "kodos.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "sunset": [
+                    "nynjaetc"
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "snowball.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "3.13.0-44-generic", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages/PILcompat"
+                ], 
+                "ip_interfaces": {
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "128.59.222.149", 
+                        "fe80::216:3eff:fee3:6186"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1491, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "dm-0", 
+                    "dm-1", 
+                    "xvda"
+                ], 
+                "mdadm": [], 
+                "id": "snowball.ccnmtl.columbia.edu", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 779549299, 
+                "lsb_distrib_description": "Ubuntu 14.04.1 LTS", 
+                "ip6_interfaces": {
+                    "lo": [
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "fe80::216:3eff:fee3:6186"
+                    ]
+                }, 
+                "num_cpus": 1, 
+                "apps": [
+                    "blackrock", 
+                    "match", 
+                    "mediathread", 
+                    "wacep", 
+                    "wings"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "eth0": [
+                        "128.59.222.149"
+                    ]
+                }, 
+                "environment": "staging", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "::1", 
+                    "fe80::216:3eff:fee3:6186"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "aes", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "dtherm"
+                ], 
+                "localhost": "snowball.columbia.edu", 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "128.59.222.149"
+                ], 
+                "fqdn_ip4": [
+                    "127.0.1.1"
+                ], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "snowball.columbia.edu", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "hwaddr_interfaces": {
+                    "lo": "00:00:00:00:00:00", 
+                    "eth0": "00:16:3e:e3:61:86"
+                }, 
+                "state_runs_disabled": [
+                    "apps.carr"
+                ], 
+                "host": "snowball", 
+                "os_family": "Debian", 
+                "proxy": [
+                    "capsim", 
+                    "wardenclyffe", 
+                    "dmt", 
+                    "forest", 
+                    "brownfield_django", 
+                    "blackrock", 
+                    "carr", 
+                    "ccdb", 
+                    "countryx", 
+                    "diabeaters", 
+                    "footprints", 
+                    "masivukeni", 
+                    "match", 
+                    "meaningfulconsent", 
+                    "mediamachine", 
+                    "mediathread", 
+                    "mvsim", 
+                    "nepi", 
+                    "pass", 
+                    "pedialabsnew", 
+                    "phtc", 
+                    "plexus", 
+                    "polarexplorer", 
+                    "pump", 
+                    "ssnm", 
+                    "tala", 
+                    "teachdentistry", 
+                    "teachrecovery", 
+                    "tobaccocessation", 
+                    "uelc", 
+                    "wacep", 
+                    "wings", 
+                    "worth2", 
+                    "caseconsortium", 
+                    "flgstatic", 
+                    "friendorfoe", 
+                    "gainesfilm", 
+                    "livingandthriving"
+                ], 
+                "oscodename": "trusty", 
+                "lito": true, 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "nginx", 
+                    "django", 
+                    "python", 
+                    "nfs"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU           X5675  @ 3.07GHz", 
+                "fqdn": "snowball.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "sunset": [
+                    "nynjaetc", 
+                    "smilekit", 
+                    "envirocon"
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "b29b5f73df1540efb74208985409e8f5", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "ceramic": {
+                "kernel": "Linux", 
+                "domain": "members.linode.com", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "ip_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.184.118", 
+                        "2600:3c03::f03c:91ff:fef1:e8e", 
+                        "fe80::f03c:91ff:fef1:e8e"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1991, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "xvda", 
+                    "xvdb", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "ceramic", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 1075318795, 
+                "lsb_distrib_description": "Ubuntu 14.04.1 LTS", 
+                "ip6_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "2600:3c03::f03c:91ff:fef1:e8e", 
+                        "fe80::f03c:91ff:fef1:e8e"
+                    ]
+                }, 
+                "num_cpus": 2, 
+                "linode": true, 
+                "apps": [
+                    "capsim", 
+                    "dmt"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.184.118"
+                    ]
+                }, 
+                "celery": [
+                    "capsim", 
+                    "dmt"
+                ], 
+                "beat": [
+                    "dmt"
+                ], 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "2600:3c03::f03c:91ff:fef1:e8e", 
+                    "::1", 
+                    "fe80::f03c:91ff:fef1:e8e"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "nonstop_tsc", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "pln", 
+                    "pts", 
+                    "dtherm", 
+                    "fsgsbase", 
+                    "erms", 
+                    "xsaveopt"
+                ], 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "45.79.184.118"
+                ], 
+                "localhost": "ceramic.ccnmtl.columbia.edu", 
+                "location": "linode", 
+                "fqdn_ip4": [
+                    "45.79.184.118"
+                ], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "li1283-118", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "hwaddr_interfaces": {
+                    "gre0": "0.0.0.0", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "sit0": "0.0.0.0", 
+                    "dummy0": "4e:a7:90:46:e3:e8", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", 
+                    "ip_vti0": "0.0.0.0", 
+                    "eth0": "f2:3c:91:f1:0e:8e"
+                }, 
+                "host": "ceramic", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "django", 
+                    "python", 
+                    "celery"
+                ], 
+                "environment": "production", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz", 
+                "fqdn": "ceramic.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu", 
+                "virtual": "xen"
+            }
+        }, 
+        {
+            "neptune.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "ip_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "23.239.15.113", 
+                        "2600:3c03::f03c:91ff:fe50:1400", 
+                        "fe80::f03c:91ff:fe50:1400"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 987, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "xvda", 
+                    "xvdb", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "neptune.ccnmtl.columbia.edu", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 1093409601, 
+                "lsb_distrib_description": "Ubuntu 14.04.1 LTS", 
+                "ip6_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "2600:3c03::f03c:91ff:fe50:1400", 
+                        "fe80::f03c:91ff:fe50:1400"
+                    ]
+                }, 
+                "num_cpus": 1, 
+                "linode": true, 
+                "hwaddr_interfaces": {
+                    "gre0": "0.0.0.0", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "sit0": "0.0.0.0", 
+                    "dummy0": "be:62:9e:f8:fa:ba", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", 
+                    "ip_vti0": "0.0.0.0", 
+                    "eth0": "f2:3c:91:50:14:00"
+                }, 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "23.239.15.113"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "2600:3c03::f03c:91ff:fe50:1400", 
+                    "::1", 
+                    "fe80::f03c:91ff:fe50:1400"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "nonstop_tsc", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "pln", 
+                    "pts", 
+                    "dtherm", 
+                    "fsgsbase", 
+                    "erms", 
+                    "xsaveopt"
+                ], 
+                "localhost": "neptune.ccnmtl.columbia.edu", 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "23.239.15.113"
+                ], 
+                "fqdn_ip4": [
+                    "23.239.15.113"
+                ], 
+                "shell": "/bin/sh", 
+                "nodename": "neptune", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "host": "neptune", 
+                "os_family": "Debian", 
+                "proxy": [
+                    "sentry", 
+                    "hound", 
+                    "cdap", 
+                    "connect", 
+                    "drinkme", 
+                    "iat", 
+                    "maap", 
+                    "omeka", 
+                    "pita", 
+                    "southside", 
+                    "countryx", 
+                    "diabeaters", 
+                    "flgstatic", 
+                    "masivukeni", 
+                    "meaningfulconsent", 
+                    "mediamachine", 
+                    "mvsim", 
+                    "pass", 
+                    "plexus", 
+                    "pump", 
+                    "ssnm", 
+                    "tala", 
+                    "teachdentistry", 
+                    "tobaccocessation", 
+                    "uelc", 
+                    "worth2", 
+                    "caseconsortium"
+                ], 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "nginx"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz", 
+                "fqdn": "neptune.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "pechora.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "ip_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.160.48", 
+                        "192.168.214.143", 
+                        "2600:3c03::f03c:91ff:fe67:3e17", 
+                        "fe80::f03c:91ff:fe67:3e17"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1991, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "xvda", 
+                    "xvdb", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "pechora.ccnmtl.columbia.edu", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 666167178, 
+                "lsb_distrib_description": "Ubuntu 14.04.3 LTS", 
+                "ip6_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "2600:3c03::f03c:91ff:fe67:3e17", 
+                        "fe80::f03c:91ff:fe67:3e17"
+                    ]
+                }, 
+                "num_cpus": 2, 
+                "linode": true, 
+                "hwaddr_interfaces": {
+                    "gre0": "0.0.0.0", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "sit0": "0.0.0.0", 
+                    "dummy0": "1a:f4:dc:8d:f3:42", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", 
+                    "ip_vti0": "0.0.0.0", 
+                    "eth0": "f2:3c:91:67:3e:17"
+                }, 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.160.48", 
+                        "192.168.214.143"
+                    ]
+                }, 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "2600:3c03::f03c:91ff:fe67:3e17", 
+                    "::1", 
+                    "fe80::f03c:91ff:fe67:3e17"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "nonstop_tsc", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "pln", 
+                    "pts", 
+                    "dtherm", 
+                    "fsgsbase", 
+                    "erms", 
+                    "xsaveopt"
+                ], 
+                "localhost": "pechora", 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "192.168.214.143", 
+                    "45.79.160.48"
+                ], 
+                "fqdn_ip4": [
+                    "45.79.160.48"
+                ], 
+                "shell": "/bin/sh", 
+                "nodename": "pechora", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "drupalapps": [
+                    "classpop", 
+                    "epistolae", 
+                    "inclusiveclassrooms", 
+                    "mathkids", 
+                    "mediathread_info", 
+                    "myny", 
+                    "pediatric_dental", 
+                    "polarhub", 
+                    "prime", 
+                    "swc"
+                ], 
+                "host": "pechora", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "lamp"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz", 
+                "fqdn": "pechora.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "cletus.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "ip_interfaces": {
+                    "veth5fcef3e": [
+                        "fe80::f8c5:afff:fee7:4756"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "dummy0": [], 
+                    "eth0": [
+                        "69.164.210.90", 
+                        "192.168.221.152", 
+                        "fe80::f03c:91ff:fe93:cde3"
+                    ], 
+                    "lxcbr0": [
+                        "10.0.3.1", 
+                        "fe80::8ce5:5ff:feca:2eca"
+                    ], 
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "veth20e6cfb": [
+                        "fe80::2022:f2ff:feb3:ff66"
+                    ], 
+                    "veth9c1a2c9": [
+                        "fe80::e82f:ceff:fe47:6c12"
+                    ], 
+                    "vethf05491c": [
+                        "fe80::480:cff:fe62:d770"
+                    ], 
+                    "veth80a3e1a": [
+                        "fe80::3c8f:20ff:fe31:299a"
+                    ], 
+                    "vetha054cda": [
+                        "fe80::2039:99ff:fe6b:29f5"
+                    ], 
+                    "docker0": [
+                        "172.17.42.1", 
+                        "fe80::dc07:b5ff:fead:f660"
+                    ], 
+                    "veth30f26e3": [
+                        "fe80::5826:cbff:fe7d:e0ef"
+                    ], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "veth90cac63": [
+                        "fe80::e89b:79ff:fe4f:a82d"
+                    ], 
+                    "ip_vti0": [], 
+                    "veth01ed48d": [
+                        "fe80::accd:91ff:fecd:9879"
+                    ], 
+                    "veth404278b": [
+                        "fe80::487b:74ff:fec7:32b8"
+                    ], 
+                    "gretap0": [], 
+                    "vethe29a17f": [
+                        "fe80::b097:1fff:fe23:1ba5"
+                    ], 
+                    "vethfd94d82": [
+                        "fe80::b88e:9cff:feeb:fd0e"
+                    ], 
+                    "ip6gre0": []
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1991, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "xvda", 
+                    "xvdb", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "cletus.ccnmtl.columbia.edu", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 515240669, 
+                "lsb_distrib_description": "Ubuntu 14.04.2 LTS", 
+                "ip6_interfaces": {
+                    "veth5fcef3e": [
+                        "fe80::f8c5:afff:fee7:4756"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "dummy0": [], 
+                    "eth0": [
+                        "fe80::f03c:91ff:fe93:cde3"
+                    ], 
+                    "lxcbr0": [
+                        "fe80::8ce5:5ff:feca:2eca"
+                    ], 
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "veth20e6cfb": [
+                        "fe80::2022:f2ff:feb3:ff66"
+                    ], 
+                    "veth9c1a2c9": [
+                        "fe80::e82f:ceff:fe47:6c12"
+                    ], 
+                    "vethf05491c": [
+                        "fe80::480:cff:fe62:d770"
+                    ], 
+                    "veth80a3e1a": [
+                        "fe80::3c8f:20ff:fe31:299a"
+                    ], 
+                    "vetha054cda": [
+                        "fe80::2039:99ff:fe6b:29f5"
+                    ], 
+                    "docker0": [
+                        "fe80::dc07:b5ff:fead:f660"
+                    ], 
+                    "veth30f26e3": [
+                        "fe80::5826:cbff:fe7d:e0ef"
+                    ], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "veth90cac63": [
+                        "fe80::e89b:79ff:fe4f:a82d"
+                    ], 
+                    "ip_vti0": [], 
+                    "veth01ed48d": [
+                        "fe80::accd:91ff:fecd:9879"
+                    ], 
+                    "veth404278b": [
+                        "fe80::487b:74ff:fec7:32b8"
+                    ], 
+                    "gretap0": [], 
+                    "vethe29a17f": [
+                        "fe80::b097:1fff:fe23:1ba5"
+                    ], 
+                    "vethfd94d82": [
+                        "fe80::b88e:9cff:feeb:fd0e"
+                    ], 
+                    "ip6gre0": []
+                }, 
+                "num_cpus": 2, 
+                "linode": true, 
+                "apps": [
+                    "sentry", 
+                    "iat", 
+                    "pita", 
+                    "maap", 
+                    "connect", 
+                    "southside", 
+                    "cdap", 
+                    "drinkme"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "veth5fcef3e": [], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "dummy0": [], 
+                    "eth0": [
+                        "69.164.210.90", 
+                        "192.168.221.152"
+                    ], 
+                    "lxcbr0": [
+                        "10.0.3.1"
+                    ], 
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "veth20e6cfb": [], 
+                    "veth9c1a2c9": [], 
+                    "vethf05491c": [], 
+                    "veth80a3e1a": [], 
+                    "vetha054cda": [], 
+                    "docker0": [
+                        "172.17.42.1"
+                    ], 
+                    "veth30f26e3": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "veth90cac63": [], 
+                    "ip_vti0": [], 
+                    "veth01ed48d": [], 
+                    "veth404278b": [], 
+                    "gretap0": [], 
+                    "vethe29a17f": [], 
+                    "vethfd94d82": [], 
+                    "ip6gre0": []
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "::1", 
+                    "fe80::2022:f2ff:feb3:ff66", 
+                    "fe80::2039:99ff:fe6b:29f5", 
+                    "fe80::3c8f:20ff:fe31:299a", 
+                    "fe80::480:cff:fe62:d770", 
+                    "fe80::487b:74ff:fec7:32b8", 
+                    "fe80::5826:cbff:fe7d:e0ef", 
+                    "fe80::8ce5:5ff:feca:2eca", 
+                    "fe80::accd:91ff:fecd:9879", 
+                    "fe80::b097:1fff:fe23:1ba5", 
+                    "fe80::b88e:9cff:feeb:fd0e", 
+                    "fe80::dc07:b5ff:fead:f660", 
+                    "fe80::e82f:ceff:fe47:6c12", 
+                    "fe80::e89b:79ff:fe4f:a82d", 
+                    "fe80::f03c:91ff:fe93:cde3", 
+                    "fe80::f8c5:afff:fee7:4756"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "nonstop_tsc", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "pln", 
+                    "pts", 
+                    "dtherm", 
+                    "fsgsbase", 
+                    "erms", 
+                    "xsaveopt"
+                ], 
+                "localhost": "cletus.ccnmtl.columbia.edu", 
+                "ipv4": [
+                    "10.0.3.1", 
+                    "127.0.0.1", 
+                    "172.17.42.1", 
+                    "192.168.221.152", 
+                    "69.164.210.90"
+                ], 
+                "fqdn_ip4": [
+                    "69.164.210.90"
+                ], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "cletus", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "hwaddr_interfaces": {
+                    "veth5fcef3e": "fa:c5:af:e7:47:56", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "dummy0": "82:ce:54:a3:f5:f9", 
+                    "eth0": "f2:3c:91:93:cd:e3", 
+                    "lxcbr0": "8e:e5:05:ca:2e:ca", 
+                    "gre0": "0.0.0.0", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "veth20e6cfb": "22:22:f2:b3:ff:66", 
+                    "veth9c1a2c9": "ea:2f:ce:47:6c:12", 
+                    "vethf05491c": "06:80:0c:62:d7:70", 
+                    "veth80a3e1a": "3e:8f:20:31:29:9a", 
+                    "vetha054cda": "22:39:99:6b:29:f5", 
+                    "docker0": "06:80:0c:62:d7:70", 
+                    "veth30f26e3": "5a:26:cb:7d:e0:ef", 
+                    "sit0": "0.0.0.0", 
+                    "veth90cac63": "ea:9b:79:4f:a8:2d", 
+                    "ip_vti0": "0.0.0.0", 
+                    "veth01ed48d": "ae:cd:91:cd:98:79", 
+                    "veth404278b": "4a:7b:74:c7:32:b8", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "vethe29a17f": "b2:97:1f:23:1b:a5", 
+                    "vethfd94d82": "ba:8e:9c:eb:fd:0e", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00"
+                }, 
+                "host": "cletus", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "nginx", 
+                    "docker", 
+                    "chimney", 
+                    "hound", 
+                    "gccnmtl", 
+                    "catcha", 
+                    "docker-mysql"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz", 
+                "fqdn": "cletus.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "polaris": {
+                "kernel": "Linux", 
+                "domain": "members.linode.com", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "ip_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.158.191", 
+                        "2600:3c03::f03c:91ff:fef1:acaa", 
+                        "fe80::f03c:91ff:fef1:acaa"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1991, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "xvda", 
+                    "xvdb", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "polaris", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 1286876123, 
+                "lsb_distrib_description": "Ubuntu 14.04.1 LTS", 
+                "ip6_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "2600:3c03::f03c:91ff:fef1:acaa", 
+                        "fe80::f03c:91ff:fef1:acaa"
+                    ]
+                }, 
+                "num_cpus": 2, 
+                "linode": true, 
+                "apps": [
+                    "capsim", 
+                    "forest", 
+                    "mediamachine", 
+                    "polarexplorer", 
+                    "carr", 
+                    "pedialabsnew"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.158.191"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "2600:3c03::f03c:91ff:fef1:acaa", 
+                    "::1", 
+                    "fe80::f03c:91ff:fef1:acaa"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "nonstop_tsc", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "pln", 
+                    "pts", 
+                    "dtherm", 
+                    "fsgsbase", 
+                    "erms", 
+                    "xsaveopt"
+                ], 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "45.79.158.191"
+                ], 
+                "localhost": "polaris.ccnmtl.columbia.edu", 
+                "location": "linode", 
+                "fqdn_ip4": [
+                    "45.79.158.191"
+                ], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "li1257-191", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "hwaddr_interfaces": {
+                    "gre0": "0.0.0.0", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "sit0": "0.0.0.0", 
+                    "dummy0": "e6:7b:33:61:6a:54", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", 
+                    "ip_vti0": "0.0.0.0", 
+                    "eth0": "f2:3c:91:f1:ac:aa"
+                }, 
+                "host": "polaris", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "django", 
+                    "python"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz", 
+                "fqdn": "polaris.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "danube.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "ip_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "23.239.15.110", 
+                        "2600:3c03::f03c:91ff:fe50:1455", 
+                        "fe80::f03c:91ff:fe50:1455"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 3998, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "xvda", 
+                    "xvdb", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "danube.ccnmtl.columbia.edu", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 946202546, 
+                "lsb_distrib_description": "Ubuntu 14.04.1 LTS", 
+                "ip6_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "2600:3c03::f03c:91ff:fe50:1455", 
+                        "fe80::f03c:91ff:fe50:1455"
+                    ]
+                }, 
+                "num_cpus": 4, 
+                "linode": true, 
+                "hwaddr_interfaces": {
+                    "gre0": "0.0.0.0", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "sit0": "0.0.0.0", 
+                    "dummy0": "06:05:3d:1d:cb:e9", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", 
+                    "ip_vti0": "0.0.0.0", 
+                    "eth0": "f2:3c:91:50:14:55"
+                }, 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "23.239.15.110"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "2600:3c03::f03c:91ff:fe50:1455", 
+                    "::1", 
+                    "fe80::f03c:91ff:fe50:1455"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "nonstop_tsc", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "pln", 
+                    "pts", 
+                    "dtherm", 
+                    "fsgsbase", 
+                    "erms", 
+                    "xsaveopt"
+                ], 
+                "localhost": "danube.ccnmtl.columbia.edu", 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "23.239.15.110"
+                ], 
+                "fqdn_ip4": [
+                    "23.239.15.110"
+                ], 
+                "shell": "/bin/sh", 
+                "nodename": "danube", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "host": "danube", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "postgresql-server", 
+                    "rabbitmq"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz", 
+                "fqdn": "danube.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "pacific.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages/PILcompat"
+                ], 
+                "ip_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "23.239.15.111", 
+                        "2600:3c03::f03c:91ff:fe50:14dc", 
+                        "fe80::f03c:91ff:fe50:14dc"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1991, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "xvda", 
+                    "xvdb", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "pacific.ccnmtl.columbia.edu", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 550919855, 
+                "lsb_distrib_description": "Ubuntu 14.04.1 LTS", 
+                "ip6_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "2600:3c03::f03c:91ff:fe50:14dc", 
+                        "fe80::f03c:91ff:fe50:14dc"
+                    ]
+                }, 
+                "num_cpus": 2, 
+                "linode": true, 
+                "apps": [
+                    "brownfield_django", 
+                    "ccdb", 
+                    "countryx", 
+                    "diabeaters", 
+                    "masivukeni", 
+                    "meaningfulconsent", 
+                    "mvsim", 
+                    "pass", 
+                    "plexus", 
+                    "pump", 
+                    "ssnm", 
+                    "tala", 
+                    "teachdentistry", 
+                    "tobaccocessation", 
+                    "uelc", 
+                    "worth2", 
+                    "dmt"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "23.239.15.111"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "2600:3c03::f03c:91ff:fe50:14dc", 
+                    "::1", 
+                    "fe80::f03c:91ff:fe50:14dc"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "nonstop_tsc", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "pln", 
+                    "pts", 
+                    "dtherm", 
+                    "fsgsbase", 
+                    "erms", 
+                    "xsaveopt"
+                ], 
+                "localhost": "pacific.ccnmtl.columbia.edu", 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "23.239.15.111"
+                ], 
+                "fqdn_ip4": [
+                    "23.239.15.111"
+                ], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "pacific.ccnmtl.columbia.edu", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "hwaddr_interfaces": {
+                    "gre0": "0.0.0.0", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "sit0": "0.0.0.0", 
+                    "dummy0": "f2:ff:0d:45:20:25", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", 
+                    "ip_vti0": "0.0.0.0", 
+                    "eth0": "f2:3c:91:50:14:dc"
+                }, 
+                "host": "pacific", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "python", 
+                    "windsock"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz", 
+                "fqdn": "pacific.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "patches.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "3.13.0-44-generic", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages/PILcompat"
+                ], 
+                "ip_interfaces": {
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "128.59.222.57", 
+                        "fe80::216:3eff:fee3:6187"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1491, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "dm-0", 
+                    "dm-1", 
+                    "xvda"
+                ], 
+                "mdadm": [], 
+                "id": "patches.ccnmtl.columbia.edu", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 222156236, 
+                "lsb_distrib_description": "Ubuntu 14.04.1 LTS", 
+                "ip6_interfaces": {
+                    "lo": [
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "fe80::216:3eff:fee3:6187"
+                    ]
+                }, 
+                "num_cpus": 1, 
+                "apps": [
+                    "blackrock", 
+                    "match", 
+                    "mediathread", 
+                    "wacep", 
+                    "wings"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "eth0": [
+                        "128.59.222.57"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "::1", 
+                    "fe80::216:3eff:fee3:6187"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "aes", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "dtherm"
+                ], 
+                "localhost": "patches.columbia.edu", 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "128.59.222.57"
+                ], 
+                "fqdn_ip4": [
+                    "127.0.1.1"
+                ], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "patches.columbia.edu", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "hwaddr_interfaces": {
+                    "lo": "00:00:00:00:00:00", 
+                    "eth0": "00:16:3e:e3:61:87"
+                }, 
+                "state_runs_disabled": [
+                    "apps.carr"
+                ], 
+                "host": "patches", 
+                "os_family": "Debian", 
+                "proxy": [
+                    "blackrock", 
+                    "match", 
+                    "mediathread", 
+                    "wacep", 
+                    "wings"
+                ], 
+                "oscodename": "trusty", 
+                "lito": true, 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "nginx", 
+                    "django", 
+                    "python", 
+                    "nfs"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU           X5675  @ 3.07GHz", 
+                "fqdn": "patches.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "sunset": [
+                    "nynjaetc", 
+                    "smilekit"
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "18c56d4b19bd6a82b186a2105409ee71", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "itchy.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "3.2.2", 
+                "kernelrelease": "3.2.0-53-generic", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-linux2", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages/PIL", 
+                    "/usr/lib/pymodules/python2.7"
+                ], 
+                "ip_interfaces": {
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "128.59.222.51", 
+                        "fe80::216:3eff:fe2a:9790"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1491, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "xvda2", 
+                    "xvda1", 
+                    "xvdb"
+                ], 
+                "mdadm": [], 
+                "id": "itchy.ccnmtl.columbia.edu", 
+                "osrelease": "12.04", 
+                "ps": "ps -efHww", 
+                "server_id": 248808391, 
+                "lsb_distrib_description": "Ubuntu 12.04.4 LTS", 
+                "ip6_interfaces": {
+                    "lo": [
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "fe80::216:3eff:fe2a:9790"
+                    ]
+                }, 
+                "num_cpus": 1, 
+                "apps": [
+                    "footprints", 
+                    "nepi", 
+                    "phtc"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "eth0": [
+                        "128.59.222.51"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "::1", 
+                    "fe80::216:3eff:fe2a:9790"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "up", 
+                    "rep_good", 
+                    "nopl", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "vmx", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "aes", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "tpr_shadow", 
+                    "vnmi", 
+                    "flexpriority", 
+                    "ept", 
+                    "vpid"
+                ], 
+                "localhost": "itchy", 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "128.59.222.51"
+                ], 
+                "fqdn_ip4": [
+                    "127.0.1.1"
+                ], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "itchy", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "12.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "hwaddr_interfaces": {
+                    "lo": "00:00:00:00:00:00", 
+                    "eth0": "00:16:3e:2a:97:90"
+                }, 
+                "host": "itchy", 
+                "os_family": "Debian", 
+                "proxy": [
+                    "brownfield_django", 
+                    "footprints", 
+                    "nepi", 
+                    "phtc", 
+                    "polarexplorer"
+                ], 
+                "oscodename": "precise", 
+                "lito": true, 
+                "osfinger": "Ubuntu-12.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    3, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "nginx", 
+                    "django", 
+                    "python", 
+                    "windsock", 
+                    "dumppg", 
+                    "nfs"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU           E5645  @ 2.40GHz", 
+                "fqdn": "itchy.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "precise", 
+                "osrelease_info": [
+                    12, 
+                    4
+                ], 
+                "sunset": [
+                    "npo", 
+                    "teachrecovery", 
+                    "worth", 
+                    "worthstudydata", 
+                    "envirocon"
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "scratchy.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "3.2.0-53-generic", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-linux2", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages/PIL", 
+                    "/usr/lib/pymodules/python2.7"
+                ], 
+                "ip_interfaces": {
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "128.59.222.52", 
+                        "fe80::216:3eff:fe69:2728"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1491, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "xvda2", 
+                    "xvda1", 
+                    "xvdb"
+                ], 
+                "mdadm": [], 
+                "id": "scratchy.ccnmtl.columbia.edu", 
+                "osrelease": "12.04", 
+                "ps": "ps -efHww", 
+                "server_id": 190653374, 
+                "lsb_distrib_description": "Ubuntu 12.04.5 LTS", 
+                "ip6_interfaces": {
+                    "lo": [
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "fe80::216:3eff:fe69:2728"
+                    ]
+                }, 
+                "num_cpus": 1, 
+                "apps": [
+                    "footprints", 
+                    "nepi", 
+                    "phtc"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "eth0": [
+                        "128.59.222.52"
+                    ]
+                }, 
+                "environment": "staging", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "::1", 
+                    "fe80::216:3eff:fe69:2728"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "up", 
+                    "rep_good", 
+                    "nopl", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "vmx", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "aes", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "tpr_shadow", 
+                    "vnmi", 
+                    "flexpriority", 
+                    "ept", 
+                    "vpid"
+                ], 
+                "localhost": "scratchy.ccnmtl.columbia.edu", 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "128.59.222.52"
+                ], 
+                "fqdn_ip4": [
+                    "127.0.1.1"
+                ], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "scratchy.ccnmtl.columbia.edu", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "12.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "hwaddr_interfaces": {
+                    "lo": "00:00:00:00:00:00", 
+                    "eth0": "00:16:3e:69:27:28"
+                }, 
+                "state_runs_disabled": [
+                    "apps.polarexplorer"
+                ], 
+                "host": "scratchy", 
+                "os_family": "Debian", 
+                "oscodename": "precise", 
+                "lito": true, 
+                "osfinger": "Ubuntu-12.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    3, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "nginx", 
+                    "django", 
+                    "python", 
+                    "windsock", 
+                    "nfs"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU           E5645  @ 2.40GHz", 
+                "fqdn": "scratchy.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "precise", 
+                "osrelease_info": [
+                    12, 
+                    4
+                ], 
+                "sunset": [
+                    "teachrecovery", 
+                    "npo"
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "parrel.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "ip_interfaces": {
+                    "lxcbr0": [
+                        "10.0.3.1", 
+                        "fe80::b474:aff:fec4:7dc4"
+                    ], 
+                    "gre0": [], 
+                    "docker0": [
+                        "172.17.42.1", 
+                        "fe80::60f1:a1ff:fe54:478e"
+                    ], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "veth34ca671": [
+                        "fe80::f41a:42ff:fe3b:1563"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "veth12de16b": [
+                        "fe80::dc7f:e5ff:feee:5fb2"
+                    ], 
+                    "veth67af1b9": [
+                        "fe80::f417:a9ff:fe9b:85c0"
+                    ], 
+                    "teql0": [], 
+                    "vethbb10833": [
+                        "fe80::743c:1eff:fe8a:599"
+                    ], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "vethea229a5": [
+                        "fe80::60ec:3eff:fe9b:e92d"
+                    ], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.129.101", 
+                        "192.168.206.181", 
+                        "2600:3c03::f03c:91ff:fe67:8d0d", 
+                        "fe80::f03c:91ff:fe67:8d0d"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 987, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "xvda", 
+                    "xvdb", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "parrel.ccnmtl.columbia.edu", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 1159232553, 
+                "lsb_distrib_description": "Ubuntu 14.04.1 LTS", 
+                "ip6_interfaces": {
+                    "lxcbr0": [
+                        "fe80::b474:aff:fec4:7dc4"
+                    ], 
+                    "gre0": [], 
+                    "docker0": [
+                        "fe80::60f1:a1ff:fe54:478e"
+                    ], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "veth34ca671": [
+                        "fe80::f41a:42ff:fe3b:1563"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "veth12de16b": [
+                        "fe80::dc7f:e5ff:feee:5fb2"
+                    ], 
+                    "veth67af1b9": [
+                        "fe80::f417:a9ff:fe9b:85c0"
+                    ], 
+                    "teql0": [], 
+                    "vethbb10833": [
+                        "fe80::743c:1eff:fe8a:599"
+                    ], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "vethea229a5": [
+                        "fe80::60ec:3eff:fe9b:e92d"
+                    ], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "2600:3c03::f03c:91ff:fe67:8d0d", 
+                        "fe80::f03c:91ff:fe67:8d0d"
+                    ]
+                }, 
+                "num_cpus": 1, 
+                "linode": true, 
+                "hwaddr_interfaces": {
+                    "lxcbr0": "b6:74:0a:c4:7d:c4", 
+                    "gre0": "0.0.0.0", 
+                    "docker0": "62:ec:3e:9b:e9:2d", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "veth34ca671": "f6:1a:42:3b:15:63", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "veth12de16b": "de:7f:e5:ee:5f:b2", 
+                    "veth67af1b9": "f6:17:a9:9b:85:c0", 
+                    "vethbb10833": "76:3c:1e:8a:05:99", 
+                    "sit0": "0.0.0.0", 
+                    "dummy0": "da:1e:55:6e:70:e8", 
+                    "vethea229a5": "62:ec:3e:9b:e9:2d", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", 
+                    "ip_vti0": "0.0.0.0", 
+                    "eth0": "f2:3c:91:67:8d:0d"
+                }, 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "lxcbr0": [
+                        "10.0.3.1"
+                    ], 
+                    "gre0": [], 
+                    "docker0": [
+                        "172.17.42.1"
+                    ], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "veth34ca671": [], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "veth12de16b": [], 
+                    "veth67af1b9": [], 
+                    "teql0": [], 
+                    "vethbb10833": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "vethea229a5": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.129.101", 
+                        "192.168.206.181"
+                    ]
+                }, 
+                "environment": "production", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "2600:3c03::f03c:91ff:fe67:8d0d", 
+                    "::1", 
+                    "fe80::60ec:3eff:fe9b:e92d", 
+                    "fe80::60f1:a1ff:fe54:478e", 
+                    "fe80::743c:1eff:fe8a:599", 
+                    "fe80::b474:aff:fec4:7dc4", 
+                    "fe80::dc7f:e5ff:feee:5fb2", 
+                    "fe80::f03c:91ff:fe67:8d0d", 
+                    "fe80::f417:a9ff:fe9b:85c0", 
+                    "fe80::f41a:42ff:fe3b:1563"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "nonstop_tsc", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "fma", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "movbe", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "abm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "pln", 
+                    "pts", 
+                    "dtherm", 
+                    "fsgsbase", 
+                    "bmi1", 
+                    "avx2", 
+                    "bmi2", 
+                    "erms", 
+                    "xsaveopt"
+                ], 
+                "ipv4": [
+                    "10.0.3.1", 
+                    "127.0.0.1", 
+                    "172.17.42.1", 
+                    "192.168.206.181", 
+                    "45.79.129.101"
+                ], 
+                "localhost": "parrel", 
+                "location": "linode", 
+                "fqdn_ip4": [
+                    "45.79.129.101"
+                ], 
+                "shell": "/bin/sh", 
+                "nodename": "parrel", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "host": "parrel", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "docker"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz", 
+                "fqdn": "parrel.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "krusty.ccnmtl.columbia.edu": {
+                "kernel": "Linux", 
+                "domain": "ccnmtl.columbia.edu", 
+                "zmqversion": "3.2.2", 
+                "kernelrelease": "3.2.0-49-virtual", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-linux2", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages/PIL", 
+                    "/usr/lib/pymodules/python2.7"
+                ], 
+                "ip_interfaces": {
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "128.59.152.249", 
+                        "fe80::216:3eff:fe3b:1544"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 989, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "xvda2", 
+                    "xvda1", 
+                    "xvda3", 
+                    "xvda4"
+                ], 
+                "mdadm": [], 
+                "id": "krusty.ccnmtl.columbia.edu", 
+                "osrelease": "12.04", 
+                "ps": "ps -efHww", 
+                "server_id": 1701366309, 
+                "lsb_distrib_description": "Ubuntu 12.04.3 LTS", 
+                "ip6_interfaces": {
+                    "lo": [
+                        "::1"
+                    ], 
+                    "eth0": [
+                        "fe80::216:3eff:fe3b:1544"
+                    ]
+                }, 
+                "num_cpus": 4, 
+                "apps": [
+                    "wardenclyffe"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "eth0": [
+                        "128.59.152.249"
+                    ]
+                }, 
+                "environment": "production", 
+                "lsb_distrib_release": "12.04", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "lsb_distrib_id": "Ubuntu", 
+                "ipv6": [
+                    "::1", 
+                    "fe80::216:3eff:fe3b:1544"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "lm", 
+                    "constant_tsc", 
+                    "nopl", 
+                    "pni", 
+                    "cid", 
+                    "cx16"
+                ], 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "128.59.152.249"
+                ], 
+                "localhost": "krusty", 
+                "virtual_subtype": "Xen PV DomU", 
+                "fqdn_ip4": [
+                    "127.0.1.1"
+                ], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "krusty", 
+                "saltversion": "2015.5.3", 
+                "beat": [
+                    "wardenclyffe"
+                ], 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "hwaddr_interfaces": {
+                    "lo": "00:00:00:00:00:00", 
+                    "eth0": "00:16:3e:3b:15:44"
+                }, 
+                "host": "krusty", 
+                "os_family": "Debian", 
+                "proxy": [
+                    "wardenclyffe"
+                ], 
+                "oscodename": "precise", 
+                "osfinger": "Ubuntu-12.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    3, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "nginx", 
+                    "django", 
+                    "python"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(TM) CPU 2.80GHz", 
+                "fqdn": "krusty.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "precise", 
+                "osrelease_info": [
+                    12, 
+                    4
+                ], 
+                "celery": [
+                    "wardenclyffe"
+                ], 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "saturn": {
+                "kernel": "Linux", 
+                "domain": "members.linode.com", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages/PILcompat"
+                ], 
+                "ip_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "96.126.115.121", 
+                        "2600:3c00::f03c:91ff:fe61:45a2", 
+                        "fe80::f03c:91ff:fe61:45a2"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1991, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "xvda", 
+                    "xvdb", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "saturn", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 2023507035, 
+                "lsb_distrib_description": "Ubuntu 14.04.1 LTS", 
+                "ip6_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "2600:3c00::f03c:91ff:fe61:45a2", 
+                        "fe80::f03c:91ff:fe61:45a2"
+                    ]
+                }, 
+                "num_cpus": 2, 
+                "linode": true, 
+                "apps": [
+                    "capsim", 
+                    "carr", 
+                    "wardenclyffe", 
+                    "dmt", 
+                    "forest", 
+                    "pedialabsnew", 
+                    "polarexplorer"
+                ], 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "96.126.115.121"
+                    ]
+                }, 
+                "environment": "staging", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "2600:3c00::f03c:91ff:fe61:45a2", 
+                    "::1", 
+                    "fe80::f03c:91ff:fe61:45a2"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "nonstop_tsc", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "pln", 
+                    "pts", 
+                    "dtherm", 
+                    "fsgsbase", 
+                    "erms", 
+                    "xsaveopt"
+                ], 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "96.126.115.121"
+                ], 
+                "localhost": "saturn.ccnmtl.columbia.edu", 
+                "location": "linode", 
+                "fqdn_ip4": [
+                    "96.126.115.121"
+                ], 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "shell": "/bin/sh", 
+                "nodename": "saturn.ccnmtl.columbia.edu", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "hwaddr_interfaces": {
+                    "gre0": "0.0.0.0", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "sit0": "0.0.0.0", 
+                    "dummy0": "22:1a:01:23:70:98", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", 
+                    "ip_vti0": "0.0.0.0", 
+                    "eth0": "f2:3c:91:61:45:a2"
+                }, 
+                "host": "saturn", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "django", 
+                    "python"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz", 
+                "fqdn": "saturn.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu"
+            }
+        }, 
+        {
+            "dallas": {
+                "kernel": "Linux", 
+                "domain": "members.linode.com", 
+                "zmqversion": "4.0.4", 
+                "kernelrelease": "4.1.5-x86_64-linode61", 
+                "pythonpath": [
+                    "/usr/bin", 
+                    "/usr/lib/python2.7", 
+                    "/usr/lib/python2.7/plat-x86_64-linux-gnu", 
+                    "/usr/lib/python2.7/lib-tk", 
+                    "/usr/lib/python2.7/lib-old", 
+                    "/usr/lib/python2.7/lib-dynload", 
+                    "/usr/local/lib/python2.7/dist-packages", 
+                    "/usr/lib/python2.7/dist-packages"
+                ], 
+                "ip_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1", 
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.10.204", 
+                        "2600:3c00::f03c:91ff:fe61:8c61", 
+                        "fe80::f03c:91ff:fe61:8c61"
+                    ]
+                }, 
+                "fqdn_ip6": [], 
+                "mem_total": 1991, 
+                "saltversioninfo": [
+                    2015, 
+                    5, 
+                    3, 
+                    0
+                ], 
+                "SSDs": [
+                    "nbd0", 
+                    "nbd1", 
+                    "nbd2", 
+                    "nbd3", 
+                    "nbd4", 
+                    "nbd5", 
+                    "nbd6", 
+                    "nbd7", 
+                    "nbd8", 
+                    "nbd9", 
+                    "xvda", 
+                    "xvdb", 
+                    "nbd10", 
+                    "nbd11", 
+                    "nbd12", 
+                    "nbd13", 
+                    "nbd14", 
+                    "nbd15"
+                ], 
+                "mdadm": [], 
+                "id": "dallas", 
+                "osrelease": "14.04", 
+                "ps": "ps -efHww", 
+                "server_id": 1672207271, 
+                "lsb_distrib_description": "Ubuntu 14.04.1 LTS", 
+                "ip6_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "::1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "2600:3c00::f03c:91ff:fe61:8c61", 
+                        "fe80::f03c:91ff:fe61:8c61"
+                    ]
+                }, 
+                "num_cpus": 2, 
+                "linode": true, 
+                "hwaddr_interfaces": {
+                    "gre0": "0.0.0.0", 
+                    "ip6tnl0": "::", 
+                    "lo": "00:00:00:00:00:00", 
+                    "tunl0": "0.0.0.0", 
+                    "ip6_vti0": "::", 
+                    "gretap0": "00:00:00:00:00:00", 
+                    "sit0": "0.0.0.0", 
+                    "dummy0": "f2:5d:57:3f:ab:77", 
+                    "ip6gre0": "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00", 
+                    "ip_vti0": "0.0.0.0", 
+                    "eth0": "f2:3c:91:61:8c:61"
+                }, 
+                "osfullname": "Ubuntu", 
+                "ip4_interfaces": {
+                    "gre0": [], 
+                    "ip6tnl0": [], 
+                    "lo": [
+                        "127.0.0.1"
+                    ], 
+                    "tunl0": [], 
+                    "ip6_vti0": [], 
+                    "gretap0": [], 
+                    "teql0": [], 
+                    "sit0": [], 
+                    "dummy0": [], 
+                    "ip6gre0": [], 
+                    "ip_vti0": [], 
+                    "eth0": [
+                        "45.79.10.204"
+                    ]
+                }, 
+                "environment": "staging", 
+                "init": "upstart", 
+                "master": "mercury.ccnmtl.columbia.edu", 
+                "virtual_subtype": "Xen PV DomU", 
+                "ipv6": [
+                    "2600:3c00::f03c:91ff:fe61:8c61", 
+                    "::1", 
+                    "fe80::f03c:91ff:fe61:8c61"
+                ], 
+                "cpu_flags": [
+                    "fpu", 
+                    "de", 
+                    "tsc", 
+                    "msr", 
+                    "pae", 
+                    "cx8", 
+                    "apic", 
+                    "sep", 
+                    "cmov", 
+                    "pat", 
+                    "clflush", 
+                    "mmx", 
+                    "fxsr", 
+                    "sse", 
+                    "sse2", 
+                    "ss", 
+                    "ht", 
+                    "syscall", 
+                    "nx", 
+                    "lm", 
+                    "constant_tsc", 
+                    "rep_good", 
+                    "nopl", 
+                    "nonstop_tsc", 
+                    "eagerfpu", 
+                    "pni", 
+                    "pclmulqdq", 
+                    "ssse3", 
+                    "cx16", 
+                    "sse4_1", 
+                    "sse4_2", 
+                    "popcnt", 
+                    "tsc_deadline_timer", 
+                    "aes", 
+                    "xsave", 
+                    "avx", 
+                    "f16c", 
+                    "rdrand", 
+                    "hypervisor", 
+                    "lahf_lm", 
+                    "ida", 
+                    "arat", 
+                    "epb", 
+                    "pln", 
+                    "pts", 
+                    "dtherm", 
+                    "fsgsbase", 
+                    "erms", 
+                    "xsaveopt"
+                ], 
+                "ipv4": [
+                    "127.0.0.1", 
+                    "45.79.10.204"
+                ], 
+                "localhost": "dallas.ccnmtl.columbia.edu", 
+                "location": "linode", 
+                "fqdn_ip4": [
+                    "45.79.10.204"
+                ], 
+                "shell": "/bin/sh", 
+                "nodename": "dallas.ccnmtl.columbia.edu", 
+                "saltversion": "2015.5.3", 
+                "lsb_distrib_release": "14.04", 
+                "locale_info": {
+                    "detectedencoding": "ascii", 
+                    "defaultlanguage": null, 
+                    "defaultencoding": null
+                }, 
+                "saltpath": "/usr/lib/python2.7/dist-packages/salt", 
+                "host": "dallas", 
+                "os_family": "Debian", 
+                "oscodename": "trusty", 
+                "osfinger": "Ubuntu-14.04", 
+                "pythonversion": [
+                    2, 
+                    7, 
+                    6, 
+                    "final", 
+                    0
+                ], 
+                "num_gpus": 0, 
+                "roles": [
+                    "postgresql-server"
+                ], 
+                "virtual": "xen", 
+                "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz", 
+                "fqdn": "dallas.ccnmtl.columbia.edu", 
+                "pythonexecutable": "/usr/bin/python", 
+                "osarch": "amd64", 
+                "cpuarch": "x86_64", 
+                "lsb_distrib_codename": "trusty", 
+                "osrelease_info": [
+                    14, 
+                    4
+                ], 
+                "lsb_distrib_id": "Ubuntu", 
+                "gpus": [], 
+                "path": "/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin", 
+                "machine_id": "65c423b25e126fb664ad26f35353ca56", 
+                "os": "Ubuntu"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
a simple view that a script on the salt master can POST grains.json files to, plus a few very basic ones for viewing them.

Right now it's wide open. I want to get the basics working before thinking too much about what sort of auth we'll want (if any).