### PR TITLE
grain parsing and display

### DIFF
--- a/plexus/grainlog/grain.py
+++ b/plexus/grainlog/grain.py
@@ -1,0 +1,90 @@
+""" some convenience classes to make it easier to work with
+grain data as python objects instead of unwieldy json dicts """
+
+from collections import defaultdict
+
+
+class Grain(object):
+    def __init__(self, d):
+        self.d = d
+        self._build_indices()
+
+    def _build_indices(self):
+        self._server_idx = dict()
+        self._app_idx = defaultdict(list)
+        self._proxy_idx = defaultdict(list)
+        self._roles_idx = defaultdict(list)
+
+        for s in self.d.get('servers', []):
+            server_name = s.keys()[0]
+            server = Server(server_name, s[server_name])
+            self._server_idx[server_name] = server
+
+            for a in server.apps():
+                self._app_idx[a].append(server)
+
+            for p in server.proxy():
+                self._proxy_idx[p].append(server)
+
+            for r in server.roles():
+                self._roles_idx[r].append(server)
+
+    def servers(self):
+        return sorted(self._server_idx.values(), key=lambda x: x.name)
+
+    def server(self, server_name):
+        return self._server_idx[server_name]
+
+    def apps(self):
+        return sorted(self._app_idx.keys())
+
+    def proxies(self):
+        return sorted(self._proxy_idx.keys())
+
+    def roles(self):
+        return sorted(self._roles_idx.keys())
+
+    def app(self, app_name):
+        """ return list of Servers running the specified app """
+        return sorted(self._app_idx.get(app_name, []), key=lambda x: x.name)
+
+    def proxy(self, app_name):
+        """ return list of Servers proxying the specified app """
+        return sorted(self._proxy_idx.get(app_name, []), key=lambda x: x.name)
+
+    def role(self, role_name):
+        """ return list of Servers implementing the specified role"""
+        return sorted(self._roles_idx.get(role_name, []), key=lambda x: x.name)
+
+    def by_app(self):
+        """ return servers grouped by app (handy for template display) """
+        for app in self.apps():
+            yield dict(app=app, servers=self.app(app))
+
+    def by_proxy(self):
+        """ return servers grouped by proxy (handy for template display) """
+        for p in self.proxies():
+            yield dict(proxy=p, servers=self.proxy(p))
+
+    def by_role(self):
+        """ return servers grouped by role (handy for template display) """
+        for r in self.roles():
+            yield dict(role=r, servers=self.role(r))
+
+
+class Server(object):
+    def __init__(self, name, d):
+        self.name = name
+        self.d = d
+
+    def keys(self):
+        return self.d.keys()
+
+    def apps(self):
+        return self.d.get('apps', [])
+
+    def proxy(self):
+        return self.d.get('proxy', [])
+
+    def roles(self):
+        return self.d.get('roles', [])

--- a/plexus/grainlog/models.py
+++ b/plexus/grainlog/models.py
@@ -1,5 +1,9 @@
+import json
+
 from django.db import models
 from django.conf import settings
+
+from .grain import Grain
 
 
 class GrainLogManager(models.Manager):
@@ -32,3 +36,10 @@ class GrainLog(models.Model):
 
     class Meta:
         ordering = ['-created']
+        get_latest_by = 'created'
+
+    def data(self):
+        return json.loads(self.payload)
+
+    def grain(self):
+        return Grain(d=self.data())

--- a/plexus/grainlog/tests/test_grain.py
+++ b/plexus/grainlog/tests/test_grain.py
@@ -1,0 +1,150 @@
+import unittest
+
+from plexus.grainlog.grain import Grain, Server
+
+
+class GrainTest(unittest.TestCase):
+    def test_servers(self):
+        d = {
+            'servers': [
+                {'foo': {}},
+                {'bar': {}},
+            ]
+        }
+        g = Grain(d)
+        servers = list(g.servers())
+        self.assertEqual(len(servers), 2)
+
+    def test_server(self):
+        d = {
+            'servers': [
+                {'foo': {}},
+                {'bar': {}},
+            ]
+        }
+        g = Grain(d)
+        s = g.server('foo')
+        self.assertEqual(s.name, 'foo')
+
+    def test_app(self):
+        d = {
+            'servers': [
+                {'foo': {'apps': ['one']}},
+                {'bar': {}},
+            ]
+        }
+        g = Grain(d)
+        a = g.app('one')
+        self.assertEqual(len(a), 1)
+        self.assertEqual(a[0].name, 'foo')
+
+    def test_proxy(self):
+        d = {
+            'servers': [
+                {'foo': {'proxy': ['one']}},
+                {'bar': {}},
+            ]
+        }
+        g = Grain(d)
+        a = g.proxy('one')
+        self.assertEqual(len(a), 1)
+        self.assertEqual(a[0].name, 'foo')
+
+    def test_role(self):
+        d = {
+            'servers': [
+                {'foo': {'roles': ['one']}},
+                {'bar': {}},
+            ]
+        }
+        g = Grain(d)
+        a = g.role('one')
+        self.assertEqual(len(a), 1)
+        self.assertEqual(a[0].name, 'foo')
+
+    def test_apps(self):
+        d = {
+            'servers': [
+                {'foo': {'apps': ['one']}},
+                {'bar': {}},
+            ]
+        }
+        g = Grain(d)
+        self.assertEqual(g.apps(), ['one'])
+
+    def test_proxies(self):
+        d = {
+            'servers': [
+                {'foo': {'proxy': ['one']}},
+                {'bar': {}},
+            ]
+        }
+        g = Grain(d)
+        self.assertEqual(g.proxies(), ['one'])
+
+    def test_roles(self):
+        d = {
+            'servers': [
+                {'foo': {'roles': ['one']}},
+                {'bar': {}},
+            ]
+        }
+        g = Grain(d)
+        self.assertEqual(g.roles(), ['one'])
+
+    def test_by_app(self):
+        d = {
+            'servers': [
+                {'foo': {'apps': ['one']}},
+                {'bar': {}},
+            ]
+        }
+        g = Grain(d)
+        r = list(g.by_app())
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0]['app'], 'one')
+        self.assertEqual(r[0]['servers'][0].name, 'foo')
+
+    def test_by_proxy(self):
+        d = {
+            'servers': [
+                {'foo': {'proxy': ['one']}},
+                {'bar': {}},
+            ]
+        }
+        g = Grain(d)
+        r = list(g.by_proxy())
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0]['proxy'], 'one')
+        self.assertEqual(r[0]['servers'][0].name, 'foo')
+
+    def test_by_role(self):
+        d = {
+            'servers': [
+                {'foo': {'roles': ['one']}},
+                {'bar': {}},
+            ]
+        }
+        g = Grain(d)
+        r = list(g.by_role())
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0]['role'], 'one')
+        self.assertEqual(r[0]['servers'][0].name, 'foo')
+
+
+class ServerTest(unittest.TestCase):
+    def test_keys(self):
+        s = Server('foo', dict(a="b"))
+        self.assertEqual(s.keys(), ["a"])
+
+    def test_apps(self):
+        s = Server('foo', dict(apps=['one', 'two', 'three']))
+        self.assertEqual(s.apps(), ['one', 'two', 'three'])
+
+    def test_proxy(self):
+        s = Server('foo', dict(proxy=['one', 'two', 'three']))
+        self.assertEqual(s.proxy(), ['one', 'two', 'three'])
+
+    def test_roles(self):
+        s = Server('foo', dict(roles=['one', 'two', 'three']))
+        self.assertEqual(s.roles(), ['one', 'two', 'three'])

--- a/plexus/templates/grainlog/grainlog_detail.html
+++ b/plexus/templates/grainlog/grainlog_detail.html
@@ -5,8 +5,87 @@
 
 {% block content %}
     <p>SHA1: {{object.sha1}}</p>
+    {% with grain=object.grain %}
+
+    <h2>Summary per Server</h2>
+    {% for server in grain.servers %}
+        <h3>{{server.name}}</h3>
+        {% with apps=server.apps %}
+            {% if apps %}
+                <h4>apps</h4>
+                <ul>
+                    {% for a in server.apps %}
+                        <li>{{a}}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        {% endwith %}
+        {% with proxy=server.proxy %}
+            {% if proxy %}
+                <h4>proxy</h4>
+                <ul>
+                    {% for a in server.proxy %}
+                        <li>{{a}}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        {% endwith %}
+        {% with roles=server.roles %}
+            {% if roles %}
+                <h4>roles</h4>
+                <ul>
+                    {% for a in server.roles %}
+                        <li>{{a}}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        {% endwith %}
+    {% endfor %}
+
+    <h2>By App</h2>
+    <ul>
+        {% for a in grain.by_app %}
+            <li>{{a.app}}
+                <ul>
+                    {% for server in a.servers %}
+                        <li>{{server.name}}</li>
+                    {% endfor %}
+                </ul>
+            </li>
+        {% endfor %}
+    </ul>
+
+    <h2>By Proxy</h2>
+    <ul>
+        {% for p in grain.by_proxy %}
+            <li>{{p.proxy}}
+                <ul>
+                    {% for server in p.servers %}
+                        <li>{{server.name}}</li>
+                    {% endfor %}
+                </ul>
+            </li>
+        {% endfor %}
+    </ul>
+
+    <h2>By Role</h2>
+    <ul>
+        {% for r in grain.by_role %}
+            <li>{{r.role}}
+                <ul>
+                    {% for server in r.servers %}
+                        <li>{{server.name}}</li>
+                    {% endfor %}
+                </ul>
+            </li>
+        {% endfor %}
+    </ul>
+
+    {% endwith %}
+    <h2>Full JSON</h2>
     <pre>
 {{object.payload}}
     </pre>
+
     
 {% endblock %}


### PR DESCRIPTION
beginning to parse the data out of the big json dump and slice and dice
it in more useful ways.

The grain detail page now shows breakdowns by server, by app, by proxy,
and by role. Still ugly, but I think it's more clear where I'm going
with this.