### PR TITLE
fix bug with invalid server data

### DIFF
--- a/plexus/grainlog/grain.py
+++ b/plexus/grainlog/grain.py
@@ -17,7 +17,14 @@ class Grain(object):
 
         for s in self.d.get('servers', []):
             server_name = s.keys()[0]
-            server = Server(server_name, s[server_name])
+            data = s[server_name]
+            if not isinstance(data, dict):
+                # sometimes we get a string like
+                # "Minion did not return. [Not connected]"
+                # if salt can't talk to the minion at the moment
+                # omit that one from the list
+                continue
+            server = Server(server_name, data)
             self._server_idx[server_name] = server
 
             for a in server.apps():

--- a/plexus/grainlog/tests/test_grain.py
+++ b/plexus/grainlog/tests/test_grain.py
@@ -26,6 +26,18 @@ class GrainTest(unittest.TestCase):
         s = g.server('foo')
         self.assertEqual(s.name, 'foo')
 
+    def test_server_string(self):
+        d = {
+            'servers': [
+                {'foo': {}},
+                {'bar': "not a dict"},
+            ]
+        }
+        g = Grain(d)
+        s = g.server('foo')
+        self.assertEqual(s.name, 'foo')
+        self.assertTrue("bar" not in g.servers())
+
     def test_app(self):
         d = {
             'servers': [


### PR DESCRIPTION
See:
https://sentry.ccnmtl.columbia.edu/sentry-internal/plexus/group/1005/

Sometimes, when salt can't talk to a server, instead of a dict of grain
data for the server, we instead get the string "Minion did not return. [Not
Connected]".

Deal with this by avoiding trying to load any server data that doesn't
look like a valid dict.