### PR TITLE
Index speedup

### DIFF
--- a/plexus/main/models.py
+++ b/plexus/main/models.py
@@ -218,6 +218,10 @@ Thanks,
     def get_absolute_url(self):
         return "/alias/%d/" % self.id
 
+    def contacts(self):
+        return [ac.contact for ac in self.aliascontact_set.all(
+        ).select_related('contact')]
+
 
 class AliasContact(models.Model):
     alias = models.ForeignKey(Alias)

--- a/plexus/main/models.py
+++ b/plexus/main/models.py
@@ -278,6 +278,10 @@ class Application(models.Model):
             for sn in self.applicationnote_set.all().order_by(
                 "-note__created")]
 
+    def contacts(self):
+        return [ac.contact for ac in self.applicationcontact_set.all(
+        ).select_related('contact')]
+
 
 class ApplicationAlias(models.Model):
     application = models.ForeignKey(Application)

--- a/plexus/main/models.py
+++ b/plexus/main/models.py
@@ -98,6 +98,10 @@ class Server(models.Model):
             s = g.server(self.name + ".ccnmtl.columbia.edu")
         return s
 
+    def contacts(self):
+        return [ac.contact for ac in self.servercontact_set.all(
+        ).select_related('contact')]
+
 
 class IPAddress(models.Model):
     ipv4 = models.CharField(max_length=256)

--- a/plexus/main/views.py
+++ b/plexus/main/views.py
@@ -30,7 +30,7 @@ class IndexView(TemplateView):
     def get_context_data(self):
         return dict(
             servers=Server.objects.filter(
-                deprecated=False).order_by('name'),
+                deprecated=False).order_by('name').select_related('location'),
             aliases=(Alias.objects.all().exclude(status='deprecated')
                      .order_by('hostname')),
             applications=Application.objects.all().order_by('name'),

--- a/plexus/main/views.py
+++ b/plexus/main/views.py
@@ -35,7 +35,8 @@ class IndexView(TemplateView):
                 Alias.objects.all().exclude(status='deprecated').order_by(
                     'hostname'
                 ).select_related('ip_address__server')),
-            applications=Application.objects.all().order_by('name'),
+            applications=Application.objects.all().order_by(
+                'name').select_related('technology'),
         )
 
 

--- a/plexus/main/views.py
+++ b/plexus/main/views.py
@@ -29,7 +29,8 @@ class IndexView(TemplateView):
 
     def get_context_data(self):
         return dict(
-            servers=Server.objects.filter(deprecated=False).order_by('name'),
+            servers=Server.objects.filter(
+                deprecated=False).order_by('name'),
             aliases=(Alias.objects.all().exclude(status='deprecated')
                      .order_by('hostname')),
             applications=Application.objects.all().order_by('name'),

--- a/plexus/main/views.py
+++ b/plexus/main/views.py
@@ -31,8 +31,10 @@ class IndexView(TemplateView):
         return dict(
             servers=Server.objects.filter(
                 deprecated=False).order_by('name').select_related('location'),
-            aliases=(Alias.objects.all().exclude(status='deprecated')
-                     .order_by('hostname').select_related('ip_address__server')),
+            aliases=(
+                Alias.objects.all().exclude(status='deprecated').order_by(
+                    'hostname'
+                ).select_related('ip_address__server')),
             applications=Application.objects.all().order_by('name'),
         )
 

--- a/plexus/main/views.py
+++ b/plexus/main/views.py
@@ -32,7 +32,7 @@ class IndexView(TemplateView):
             servers=Server.objects.filter(
                 deprecated=False).order_by('name').select_related('location'),
             aliases=(Alias.objects.all().exclude(status='deprecated')
-                     .order_by('hostname')),
+                     .order_by('hostname').select_related('ip_address__server')),
             applications=Application.objects.all().order_by('name'),
         )
 

--- a/plexus/templates/main/index.html
+++ b/plexus/templates/main/index.html
@@ -26,9 +26,9 @@
 				  {% endif %}
 			</td>
 			<td>
-				{% for contact in server.contacts %}
-				<a href="/contact/{{contact.id}}/">{{contact.name}}</a>
-				{% endfor %}
+				  {% for contact in server.contacts %}
+				      <a href="/contact/{{contact.id}}/">{{contact.name}}</a>
+				  {% endfor %}
 			</td>
 
 		</tr>
@@ -37,34 +37,34 @@
 
 </table>
 {% if request.user.is_staff %}
-<p><a href="/add_server/" class="btn">Add Server</a></p>
+    <p><a href="/add_server/" class="btn">Add Server</a></p>
 {% endif %}
 
 <a id="aliases"></a><h1>Aliases</h1>
 <table class="table table-striped table-condensed table-bordered">
-	<thead>
-		<tr>
-			<th>alias</th>
-			<th>description</th>
-			<th>server</th>
-			<th>contacts</th>
-		</tr>
-	</thead>
+	  <thead>
+		    <tr>
+			      <th>alias</th>
+			      <th>description</th>
+			      <th>server</th>
+			      <th>contacts</th>
+		    </tr>
+	  </thead>
 		
-	<tbody>
-		{% for alias in aliases %}
-		<tr class="{{alias.status_css_class}}">
-			<td><a href="/alias/{{alias.id}}/">{{ alias.hostname }}</a></td>
-			<td>{{ alias.description }}</td>
-			<td><a href="/server/{{alias.ip_address.server.id}}/">{{alias.ip_address.server.name}}</a></td>
-			<td>
-				{% for ac in alias.aliascontact_set.all %}
-				<a href="/contact/{{ac.contact.id}}/">{{ac.contact.name}}</a>
-				{% endfor %}
-			</td>
-		</tr>
-		{% endfor %}
-	</tbody>
+	  <tbody>
+		    {% for alias in aliases %}
+		        <tr class="{{alias.status_css_class}}">
+			          <td><a href="/alias/{{alias.id}}/">{{ alias.hostname }}</a></td>
+			          <td>{{ alias.description }}</td>
+			          <td><a href="/server/{{alias.ip_address.server.id}}/">{{alias.ip_address.server.name}}</a></td>
+			          <td>
+				            {% for contact in alias.contacts %}
+				                <a href="/contact/{{contact.id}}/">{{contact.name}}</a>
+				            {% endfor %}
+			          </td>
+		        </tr>
+		    {% endfor %}
+	  </tbody>
 </table>
 
 <a id="applications"></a><h1>Applications</h1>

--- a/plexus/templates/main/index.html
+++ b/plexus/templates/main/index.html
@@ -30,8 +30,8 @@
 				{% endif %}
 			</td>
 			<td>
-				{% for ac in server.servercontact_set.all %}
-				<a href="/contact/{{ac.contact.id}}/">{{ac.contact.name}}</a>
+				{% for contact in server.contacts %}
+				<a href="/contact/{{contact.id}}/">{{contact.name}}</a>
 				{% endfor %}
 			</td>
 

--- a/plexus/templates/main/index.html
+++ b/plexus/templates/main/index.html
@@ -93,8 +93,8 @@
 			<td>{{ application.technology }}</td>
 			<td>{{ application.description }}</td>
 			<td>
-				{% for ac in application.applicationcontact_set.all %}
-				<a href="/contact/{{ac.contact.id}}/">{{ac.contact.name}}</a>
+				{% for contact in application.contacts %}
+				<a href="/contact/{{contact.id}}/">{{contact.name}}</a>
 				{% endfor %}
 			</td>
 		</tr>

--- a/plexus/templates/main/index.html
+++ b/plexus/templates/main/index.html
@@ -19,15 +19,11 @@
 			<td><a href="/server/{{server.id}}/">{{ server.name }}</a></td>
 			<td>{{ server.primary_function }}</td>
 			<td>
-				{% if server.virtual %}
-				{% if server.dom_u.count %}
-				{% for vm in server.dom_u.all %}<a href="/server/{{vm.dom_0.id}}/">{{vm.dom_0.name}}</a>{% endfor %}
-				{% else %}
-				Virtual
-				{% endif %}
-				{% else %}
-				{{ server.location }}
-				{% endif %}
+				  {% if server.virtual %}
+              Virtual
+				  {% else %}
+				      {{ server.location }}
+				  {% endif %}
 			</td>
 			<td>
 				{% for contact in server.contacts %}


### PR DESCRIPTION
The index page on Plexus has a lot of data there now and is starting to get a bit pokey.

Did some `.select_related()`s here and there and got it down from 920 queries and about 6s on my desktop down to 254 queries and 2s.

That's pretty much just the low hanging fruit. Almost everything that's left is the retrieving of the list of contacts for each application/alias/server. That will be a little trickier to eliminate.