### PR TITLE
fix redirect on application/server contact delete

### DIFF
--- a/plexus/main/views.py
+++ b/plexus/main/views.py
@@ -97,14 +97,14 @@ class DeleteServerContactView(DeleteView):
     model = ServerContact
 
     def get_success_url(self):
-        return reverse('server-detail', args=[self.object.id])
+        return reverse('server-detail', args=[self.object.server.id])
 
 
 class DeleteApplicationContactView(DeleteView):
     model = ApplicationContact
 
     def get_success_url(self):
-        return reverse('application-detail', args=[self.object.id])
+        return reverse('application-detail', args=[self.object.application.id])
 
 
 class AddAliasView(View):


### PR DESCRIPTION
it was using the `ApplicationContact` or `ServerContact` id rather than
the `Server` or `Application` id.