### PR TITLE
fix django-compressor requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,7 @@ djangowind==0.15.0
 django-appconf==1.0.2
 rcssmin==1.0.6
 rjsmin==1.0.12
-django_compressor==2.1
+django-compressor==2.1
 django-statsd-mozilla==0.3.16
 contextlib2==0.5.4
 raven==5.24.3


### PR DESCRIPTION
everywhere else we use 'django-compressor' instead of 'django_compressor'