### PR TITLE
elasticsearch integration for compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 db:
   image: postgres
+elasticsearch:
+  image: elasticsearch:2
 web:
-  build: .
+  image: ccnmtl/plexus
   environment:
     - APP=plexus
     - SECRET_KEY=dummy-secret-key
@@ -13,3 +15,4 @@ web:
     - "8000:8000"
   links:
     - db
+    - elasticsearch

--- a/plexus/portfolio/models.py
+++ b/plexus/portfolio/models.py
@@ -6,6 +6,7 @@ from wagtail.wagtailcore.models import Page
 from wagtail.wagtailcore.fields import RichTextField
 from wagtail.wagtailadmin.edit_handlers import FieldPanel
 from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
+from wagtail.wagtailsearch import index
 
 
 class EntryIndex(Page):
@@ -64,4 +65,13 @@ class Entry(Page):
         FieldPanel('orig_release'),
         FieldPanel('info_url'),
         FieldPanel('info_descriptor'),
+    ]
+
+    search_fields = Page.search_fields + [
+        index.SearchField('body'),
+
+        index.FilterField('partner'),
+        index.FilterField('group'),
+        index.FilterField('access'),
+        index.FilterField('status'),
     ]

--- a/plexus/settings_compose.py
+++ b/plexus/settings_compose.py
@@ -10,6 +10,15 @@ locals().update(
         INSTALLED_APPS=INSTALLED_APPS,
     ))
 
+WAGTAILSEARCH_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtail.wagtailsearch.backends.elasticsearch2',
+        'URLS': ['http://elasticsearch:9200'],
+        'INDEX': 'plexus-wagtail',
+        'TIMEOUT': 5,
+    }
+}
+
 try:
     from local_settings import *
 except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,5 +89,6 @@ django-treebeard==4.0.1
 Pillow==3.4.2
 beautifulsoup4==4.5.1
 html5lib==0.999999999
+elasticsearch==2.4.0
 
 ccnmtlsettings==1.2.0


### PR DESCRIPTION
when running locally with docker-compose, it now uses elasticsearch as
the search backend.

Assuming you have docker-compose installed properly, you should be able
to check this out on a fresh system and do:

    $ docker-compose run web migrate # to set up database schema
    $ docker-compose run web manage update_index # to create the es indices
    $ docker-compose up

and it should be running on port 8000, ready to login and start adding content.