### PR TITLE
update to newer docker-compose syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,23 @@
-db:
-  image: postgres
-elasticsearch:
-  image: elasticsearch:2
-web:
-  image: ccnmtl/plexus
-  environment:
-    - APP=plexus
-    - SECRET_KEY=dummy-secret-key
-    - SETTINGS=settings_compose
-  command: manage runserver 0.0.0.0:8000
-  volumes:
-    - .:/app/
-  ports:
-    - "8000:8000"
-  links:
-    - db
-    - elasticsearch
+version: '2'
+services:
+  db:
+    image: postgres
+  elasticsearch:
+    image: elasticsearch:2
+  web:
+    image: ccnmtl/plexus
+    environment:
+      - APP=plexus
+      - SECRET_KEY=dummy-secret-key
+      - SETTINGS=settings_compose
+    command: manage runserver 0.0.0.0:8000
+    volumes:
+      - .:/app/
+    ports:
+      - "8000:8000"
+    links:
+      - db
+      - elasticsearch
+    depends_on:
+      - db
+      - elasticsearch


### PR DESCRIPTION
this will require docker-compose of at least version 1.6.0

https://github.com/docker/compose/blob/master/CHANGELOG.md#160-2016-01-15

which introduces the `services` section, which has a nice feature of
letting you specify the dependencies between services so, eg, the django
container won't start until after the db and elasticsearch containers.

If you get:

```docker-compose up
Unsupported config option for services service: 'db'
```

that means you have an old version of docker-compose and need to update.