### PR TITLE
:arrow_up: django-storages 1.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ django-waffle==0.11.1
 django-stagingcontext==0.1.0
 django-markwhat==1.5.1
 django-impersonate==1.1
-django-storages-redux==1.3.2
+django-storages==1.5.2
 django-ga-context==0.1.0
 django-cacheds3storage==0.1.2
 django-smtp-ssl==1.0


### PR DESCRIPTION
So development for django-storages has switched back from -redux to the
original package name.

This is noted in the new changelog here:
https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst#14-2016-02-07

Because of that, we've missed the changes in the past year:
https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst#152-2017-01-13