### PR TITLE
djcelery.setup_loader()

### DIFF
--- a/plexus/settings_shared.py
+++ b/plexus/settings_shared.py
@@ -1,4 +1,5 @@
 # Django settings for plexus project.
+import djcelery
 import os.path
 from ccnmtlsettings.shared import common
 from django_feedparser.settings import *  # noqa
@@ -15,6 +16,8 @@ MIDDLEWARE_CLASSES += [  # noqa
     'wagtail.wagtailcore.middleware.SiteMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
 ]
+
+djcelery.setup_loader()
 
 INSTALLED_APPS += [  # noqa
     'bootstrapform',


### PR DESCRIPTION
forgot this little bit of config. Needed to properly pick up different
`BROKER_URL` settings in staging/prod environments.