### PR TITLE
Remove Server from admin

### DIFF
--- a/plexus/main/admin.py
+++ b/plexus/main/admin.py
@@ -1,10 +1,10 @@
-from models import Location, OSFamily, OperatingSystem, Server, IPAddress
+from models import Location, OSFamily, OperatingSystem, IPAddress
 from models import Contact, Alias, Technology
 from models import Application, ApplicationAlias, ApplicationContact
 from models import ServerContact
 from django.contrib import admin
 
-for c in [Location, OSFamily, OperatingSystem, Server, IPAddress,
+for c in [Location, OSFamily, OperatingSystem, IPAddress,
           Contact, Alias, Technology, Application, ApplicationAlias,
           ApplicationContact, ServerContact]:
     admin.site.register(c)


### PR DESCRIPTION
Servers should be added through the Add Server form, not the django admin. I'm removing Server
from the admin for now because I don't think it's necessary.