### PR TITLE
Resolve eslint warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,3 @@ MAX_COMPLEXITY=5
 all: jenkins
 
 include *.mk
-
-eslint: $(JS_SENTINAL)
-	$(NODE_MODULES)/.bin/eslint $(JS_FILES)
-
-.PHONY: eslint

--- a/django.mk
+++ b/django.mk
@@ -22,7 +22,7 @@ INTERFACE ?= localhost
 RUNSERVER_PORT ?= 8000
 PY_DIRS ?= $(APP)
 
-jenkins: check flake8 test jshint jscs
+jenkins: check flake8 test eslint jshint jscs
 
 $(PY_SENTINAL): $(REQUIREMENTS) $(VIRTUALENV) $(SUPPORT_DIR)*
 	rm -rf $(VE)

--- a/media/js/makegraphs.js
+++ b/media/js/makegraphs.js
@@ -1,3 +1,5 @@
+/* global cubism: true, d3: true */
+
 (function() {
     'use strict';
     window.makegraphs = function(el, graphite_name, size, step) {
@@ -43,11 +45,11 @@
         var metrics = metric_defs.map(gmetric);
 
         var oranges = ['#08519c', '#*82bd', '#6baed6',
-                       '#fee6ce', '#fdae6b', '#e6550d'];
+            '#fee6ce', '#fdae6b', '#e6550d'];
         var greens = ['#edf8b8', '#b2e2e2', '#66c2a4',
-                      '#2ca25f', '#006d2c'];
+            '#2ca25f', '#006d2c'];
         var blues = ['#eff3ff', '#c6dbef', '#9ecae1',
-                     '#6baed6', '#3182bd', '#08519c'];
+            '#6baed6', '#3182bd', '#08519c'];
 
         d3.select(el).call(function(div) {
             div.append('div')


### PR DESCRIPTION
js.mk now includes the eslint command. Removing the eslint definition in the outer Makefile to resolve these warnings:

```
Makefile:19: warning: overriding commands for target `eslint'
js.mk:28: warning: ignoring old commands for target `eslint'
```

Also, `eslint` was not actually running. Adding the command django.mk file and correcting resulting errors.