### PR TITLE
Tell urllib3 to use pyOpenSSL

### DIFF
--- a/plexus/settings_shared.py
+++ b/plexus/settings_shared.py
@@ -5,6 +5,11 @@ from ccnmtlsettings.shared import common
 from django_feedparser.settings import *  # noqa
 import urllib3.contrib.pyopenssl
 
+# Tell urllib3 to use pyOpenSSL. Needed by python < 2.7.9
+# to resolve an SNIMissingWarning.
+# See:
+#   https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
+#   https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
 urllib3.contrib.pyopenssl.inject_into_urllib3()
 
 project = 'plexus'

--- a/plexus/settings_shared.py
+++ b/plexus/settings_shared.py
@@ -3,6 +3,9 @@ import djcelery
 import os.path
 from ccnmtlsettings.shared import common
 from django_feedparser.settings import *  # noqa
+import urllib3.contrib.pyopenssl
+
+urllib3.contrib.pyopenssl.inject_into_urllib3()
 
 project = 'plexus'
 base = os.path.dirname(__file__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ idna==2.6
 urllib3==1.22
 certifi==2018.1.18
 cryptography==2.1.4
+asn1crypto==0.24.0  # for pyOpenSSL
+cffi==1.11.4  # for pyOpenSSL
 
 requests==2.18.4
 django-feedparser==0.2.1


### PR DESCRIPTION
Based on these instructions:
https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2

This required a few more dependencies as well.