### PR TITLE
travis: test specifically on python 2.7.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ install:
   - pip install -U setuptools
   - pip install -r requirements.txt
 python:
+  - "2.7.6"
   - "2.7"
 script:
   - make


### PR DESCRIPTION
as discussed on slack, we can tell travis to just use 2.7.6, like our jenkins and prod servers are currently at.

Testing multiple versions will slow down our travis builds but, we'll just see how this behaves.