### PR TITLE
Fix unicode grainlog encoding error

### DIFF
--- a/plexus/grainlog/tests/test_views.py
+++ b/plexus/grainlog/tests/test_views.py
@@ -74,11 +74,9 @@ class RawUpdateViewTest(ViewTest):
         self.assertEqual(request.status_code, 405)
 
     def test_post(self):
-        request = self.factory.post(reverse('grainlog-raw-update'))
-
         with open('test_data/grains.json', 'rb') as f:
-            request.FILES['payload'] = SimpleUploadedFile(
-                "grains.json", f.read())
-            request.user = self.anon
-            response = GrainLogListView.as_view()(request)
+            response = self.client.post(reverse('grainlog-raw-update'), {
+                'payload': SimpleUploadedFile('grains.json', f.read()),
+            })
+
             self.assertEqual(response.status_code, 302)

--- a/plexus/grainlog/views.py
+++ b/plexus/grainlog/views.py
@@ -6,6 +6,7 @@ from django.http.response import (
     HttpResponseNotFound,
 )
 from django.views.generic import ListView, DetailView, View
+from django.utils.encoding import smart_text
 
 from plexus.grainlog.models import GrainLog
 from plexus.main.views import LoggedInMixin
@@ -38,8 +39,10 @@ class RawUpdateView(View):
         # typical grainlog uploads are around 200k, which
         # is small enough that I think we can get away
         # with just turning it into a string in memory
-        payload = ''.join(list(f.chunks()))
+        payload = ''
+        for chunk in f.chunks():
+            payload.join(smart_text(chunk))
 
-        sha1 = hashlib.sha1(payload).hexdigest()  # nosec
+        sha1 = hashlib.sha1(payload.encode('utf-8')).hexdigest()  # nosec
         gl = self.model.objects.create_grainlog(sha1=sha1, payload=payload)
         return HttpResponseRedirect(reverse('grainlog-detail', args=[gl.id]))


### PR DESCRIPTION
This unittest wasn't properly catching this python 3 error, so I've fixed that as well.