### PR TITLE
:arrow_up: pylint 2.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ flake8==3.7.8
 logilab-common==1.4.3
 logilab-astng==0.24.3
 editdistance==0.5.3
-pylint==1.9.5 # pyup: <2.0.0
+pylint==2.3.1
 ipaddress==1.0.22
 text-unidecode==1.2
 Faker==2.0.0


### PR DESCRIPTION
This was pinned because of dropping python 2 support, and can be unpinned now.