### PR TITLE
Remove unnecessary urllib3 SSL fix

### DIFF
--- a/plexus/settings_shared.py
+++ b/plexus/settings_shared.py
@@ -2,14 +2,7 @@
 import os.path
 from ccnmtlsettings.shared import common
 from django_feedparser.settings import *  # noqa
-import urllib3.contrib.pyopenssl
 
-# Tell urllib3 to use pyOpenSSL. Needed by python < 2.7.9
-# to resolve an SNIMissingWarning.
-# See:
-#   https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
-#   https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
-urllib3.contrib.pyopenssl.inject_into_urllib3()
 
 project = 'plexus'
 base = os.path.dirname(__file__)


### PR DESCRIPTION
plexus is now on python3, and no longer needs this.