### PR TITLE
IPAddress model: order by IP address

### DIFF
--- a/plexus/main/models.py
+++ b/plexus/main/models.py
@@ -112,6 +112,9 @@ class Server(models.Model):
 
 @python_2_unicode_compatible
 class IPAddress(models.Model):
+    class Meta:
+        ordering = ('ipv4',)
+
     ipv4 = models.CharField(max_length=256)
     mac_addr = models.CharField(max_length=256, null=True, blank=True)
     server = models.ForeignKey(Server)


### PR DESCRIPTION
This causes the IP addresses to be sorted in the Django admin's form for
the Alias model.