### PR TITLE
Don't encode payload to bytes before creating GrainLog

### DIFF
--- a/plexus/grainlog/views.py
+++ b/plexus/grainlog/views.py
@@ -43,6 +43,5 @@ class RawUpdateView(View):
         encoded_payload = payload.encode('utf-8')
 
         sha1 = hashlib.sha1(encoded_payload).hexdigest()  # nosec
-        gl = self.model.objects.create_grainlog(sha1=sha1,
-                                                payload=encoded_payload)
+        gl = self.model.objects.create_grainlog(sha1=sha1, payload=payload)
         return HttpResponseRedirect(reverse('grainlog-detail', args=[gl.id]))


### PR DESCRIPTION
Trust smart_text() to handle this correctly. Needed for Django 2.2
upgrade.

encoded_payload is still needed for making the sha1 hash.