### PR TITLE
Add missing deps for new flake8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,8 @@ pyflakes==2.2.0
 mccabe==0.6.1
 pycodestyle==2.6.0
 configparser==5.0.0
+importlib-metadata==1.6.0  # for flake8
+zipp==3.1.0  # for flake8
 flake8==3.8.1
 editdistance==0.5.3
 astroid==2.4.1


### PR DESCRIPTION
To fix error found on jenkins:

```
    from flake8._compat import lru_cache
  File "/mnt/jenkins/jobs/plexus/workspace/ve/lib/python3.6/site-packages/flake8/_compat.py", line 12, in <module>
    import importlib_metadata
ModuleNotFoundError: No module named 'importlib_metadata'
```