### PR TITLE
Remove celery dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -100,13 +100,6 @@ beautifulsoup4==4.9.3
 
 html5lib==1.1
 
-anyjson==0.3.3
-vine==1.3.0
-billiard==3.6.4.0
-kombu>=3.0.37,<4
-amqp==2.6.1
-amqplib==1.0.2
-
 ccnmtlsettings==1.9.0
 
 pbr==5.6.0


### PR DESCRIPTION
Queues were removed a while ago. Now removing the related libraries.