### PR TITLE
Use ccnmtl s3prefix

### DIFF
--- a/plexus/settings_production.py
+++ b/plexus/settings_production.py
@@ -12,6 +12,7 @@ locals().update(
     common(
         project=project,
         base=base,
+        s3prefix="ccnmtl",
         STATIC_ROOT=STATIC_ROOT,  # noqa: F405
         INSTALLED_APPS=INSTALLED_APPS,  # noqa: F405
         cloudfront="d35pxobnzf6ttf",

--- a/plexus/settings_staging.py
+++ b/plexus/settings_staging.py
@@ -12,6 +12,7 @@ locals().update(
     common(
         project=project,
         base=base,
+        s3prefix="ccnmtl",
         STATIC_ROOT=STATIC_ROOT,  # noqa: F405
         INSTALLED_APPS=INSTALLED_APPS,  # noqa: F405
         cloudfront="d1vy4q2u1y7bpg",


### PR DESCRIPTION
The new default for this is 'ctl', in ctlsettings: https://github.com/ccnmtl/ctlsettings/blob/main/ctlsettings/staging.py#L11

But, the plexus bucket names, and for most our apps, are still prefixed with "ccnmtl". So, just declare this manually as needed.