### PR TITLE
Add missing AppConfig stuff

### DIFF
--- a/plexus/grainlog/apps.py
+++ b/plexus/grainlog/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class GrainlogConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'plexus.grainlog'

--- a/plexus/main/apps.py
+++ b/plexus/main/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class MainConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'plexus.main'


### PR DESCRIPTION
This change fixes deprecation warnings:
```
main.ServerNote: (models.W042) Auto-created primary key used when not
defining a primary key type, by default 'django.db.models.AutoField'.
        HINT: Configure the DEFAULT_AUTO_FIELD setting or the
        AppConfig.default_auto_field attribute to point to a subclass of
        AutoField, e.g. 'django.db.models.BigAutoField'
```