### PR TITLE
Store payload as string rather than bytestring

### DIFF
--- a/plexus/grainlog/views.py
+++ b/plexus/grainlog/views.py
@@ -6,7 +6,7 @@ from django.http.response import (
     HttpResponseNotFound,
 )
 from django.views.generic import ListView, DetailView, View
-from django.utils.encoding import smart_bytes
+from django.utils.encoding import smart_str, smart_bytes
 
 from plexus.grainlog.models import GrainLog
 from plexus.main.views import LoggedInMixin
@@ -39,8 +39,9 @@ class RawUpdateView(View):
         # typical grainlog uploads are around 200k, which
         # is small enough that I think we can get away
         # with just turning it into a string in memory
-        payload = smart_bytes(f.read())
+        payload = smart_str(f.read())
+        encoded_payload = smart_bytes(payload)
 
-        sha1 = hashlib.sha1(payload).hexdigest()  # nosec
+        sha1 = hashlib.sha1(encoded_payload).hexdigest()  # nosec
         gl = self.model.objects.create_grainlog(sha1=sha1, payload=payload)
         return HttpResponseRedirect(reverse('grainlog-detail', args=[gl.id]))


### PR DESCRIPTION
Python3 text stuff can be confusing - this should address the error.